### PR TITLE
Initialize Che Devfile Registry

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,21 @@
+Header set Access-Control-Allow-Origin "*"
+Header set Access-Control-Allow-Headers "Authorization"
+DirectoryIndex README.md
+
+<FilesMatch "\.(json|yaml)$">
+
+  <IfModule mod_expires.c>
+    ExpiresActive Off
+  </IfModule>
+
+  <IfModule mod_headers.c>
+    FileETag None
+    Header unset ETag
+    Header unset Pragma
+    Header unset Cache-Control
+    Header unset Last-Modified
+    Header set Pragma "no-cache"
+    Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+    Header set Expires "Mon, 10 Apr 1972 00:00:00 GMT"
+  </IfModule>
+</FilesMatch>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+FROM mikefarah/yq as builder
+RUN apk add --no-cache bash
+
+COPY .htaccess README.md *.sh /build/
+COPY /devfiles /build/devfiles
+WORKDIR /build/
+RUN ./index.sh > /build/devfiles/index.json
+
+FROM registry.centos.org/centos/httpd-24-centos7
+RUN mkdir /var/www/html/devfiles
+COPY --from=builder /build/ /var/www/html/
+USER 0
+RUN chmod -R g+rwX /var/www/html/devfiles

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+FROM mikefarah/yq as builder
+RUN apk add --no-cache bash
+
+COPY .htaccess README.md *.sh /build/
+COPY /devfiles /build/devfiles
+WORKDIR /build/
+RUN ./index.sh > /build/devfiles/index.json
+
+FROM quay.io/openshiftio/rhel-base-httpd:latest
+
+RUN sed -i -e "s,Listen 80,Listen 8080," /etc/httpd/conf/httpd.conf
+RUN sed -i -e "s,logs/error_log,/dev/stderr," /etc/httpd/conf/httpd.conf
+RUN sed -i -e "s,logs/access_log,/dev/stdout," /etc/httpd/conf/httpd.conf
+RUN sed -i -e "s,AllowOverride None,AllowOverride All," /etc/httpd/conf/httpd.conf
+
+EXPOSE 80
+
+# the htpasswd file may be periodically replaced during run
+RUN chmod a+rwX            /etc/httpd/conf
+RUN chmod a+rwX            /run/httpd
+
+RUN mkdir /var/www/html/devfiles
+COPY --from=builder /build/ /var/www/html/
+USER 0
+RUN chmod -R g+rwX /var/www/html/devfiles
+
+STOPSIGNAL SIGWINCH
+
+ENTRYPOINT ["/usr/sbin/httpd", "-D", "FOREGROUND"]

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+docker build -t eclipse/che-devfile-registry:latest .

--- a/cico_build.sh
+++ b/cico_build.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+# Output command before executing
+set -x
+
+# Exit on error
+set -e
+
+# Source environment variables of the jenkins slave
+# that might interest this worker.
+function load_jenkins_vars() {
+  if [ -e "jenkins-env.json" ]; then
+    eval "$(./env-toolkit load -f jenkins-env.json \
+            DEVSHIFT_TAG_LEN \
+            QUAY_USERNAME \
+            QUAY_PASSWORD \
+            JENKINS_URL \
+            GIT_BRANCH \
+            GIT_COMMIT \
+            BUILD_NUMBER \
+            ghprbSourceBranch \
+            ghprbActualCommit \
+            BUILD_URL \
+            ghprbPullId)"
+  fi
+}
+
+function install_deps() {
+  # We need to disable selinux for now, XXX
+  /usr/sbin/setenforce 0  || true
+
+  # Get all the deps in
+  yum install -y yum-utils device-mapper-persistent-data lvm2
+  yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+  yum install -y docker-ce \
+    git
+
+  service docker start
+
+  echo 'CICO: Dependencies installed'
+}
+
+function tag_push() {
+  local TARGET=$1
+  docker tag "${IMAGE}" "$TARGET"
+  docker push "$TARGET"
+}
+
+function deploy() {
+  TARGET=${TARGET:-"centos"}
+  REGISTRY="quay.io"
+
+  if [ "$TARGET" == "rhel" ]; then
+    DOCKERFILE="Dockerfile.rhel"
+    IMAGE="rhel-che-devfile-registry"
+  else
+    DOCKERFILE="Dockerfile"
+    IMAGE="che-devfile-registry"
+  fi
+
+  if [ -n "${QUAY_USERNAME}" ] && [ -n "${QUAY_PASSWORD}" ]; then
+    docker login -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" "${REGISTRY}"
+  else
+    echo "Could not login, missing credentials for the registry"
+  fi
+
+  # Let's deploy
+  docker build -t ${IMAGE} -f ${DOCKERFILE} .
+
+  TAG=$(echo "$GIT_COMMIT" | cut -c1-"${DEVSHIFT_TAG_LEN}")
+
+  tag_push "${REGISTRY}/openshiftio/$IMAGE:$TAG"
+  tag_push "${REGISTRY}/openshiftio/$IMAGE:latest"
+  echo 'CICO: Image pushed, ready to update deployed app'
+}
+
+function cico_setup() {
+  load_jenkins_vars;
+  install_deps;
+}
+cico_setup
+deploy

--- a/deploy/kubernetes/che-devfile-registry/Chart.yaml
+++ b/deploy/kubernetes/che-devfile-registry/Chart.yaml
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: "v1"
+name: "che-devfile-registry-service"
+version: "0.0.1"
+home: "https://github.com/eclipse/che-devfile-registry/"

--- a/deploy/kubernetes/che-devfile-registry/README.md
+++ b/deploy/kubernetes/che-devfile-registry/README.md
@@ -1,0 +1,3 @@
+# Che devfile Registry Helm Chart
+
+This Helm Chart install [Che](https://github.com/eclipse/che) devfile Registry. More information about Che devfile Registry can be found [here](https://github.com/eclipse/che-devfile-registry).

--- a/deploy/kubernetes/che-devfile-registry/templates/deployment.yaml
+++ b/deploy/kubernetes/che-devfile-registry/templates/deployment.yaml
@@ -1,0 +1,61 @@
+#
+# Copyright (c) 2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: che-devfile-registry
+  name: che-devfile-registry
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: che-devfile-registry
+  strategy:
+    type: RollingUpdate
+    rollingParams:
+      intervalSeconds: 1
+      maxSurge: 25%
+      maxUnavailable: 25%
+      timeoutSeconds: 600
+      updatePeriodSeconds: 1
+  template:
+    metadata:
+      labels:
+        app: che-devfile-registry
+    spec:
+      containers:
+      - image: {{ .Values.cheDevfileRegistryImage }}
+        imagePullPolicy: {{ .Values.cheDevfileRegistryImagePullPolicy }}
+        name: che-devfile-registry
+        ports:
+        - containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /devfiles/
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /devfiles/
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 3
+          periodSeconds: 10
+          timeoutSeconds: 3
+        resources:
+          limits:
+            memory: {{ .Values.cheDevfileRegistryMemoryLimit }}
+          requests:
+            memory: 256Mi

--- a/deploy/kubernetes/che-devfile-registry/templates/ingress.yaml
+++ b/deploy/kubernetes/che-devfile-registry/templates/ingress.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: che-devfile-registry
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.global.ingress.class }}
+spec:
+  rules:
+  - host: {{ printf "che-devfile-registry-%s.%s" .Release.Namespace .Values.global.ingressDomain }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: che-devfile-registry
+          servicePort: 8080
+{{- if .Values.cheDevfileRegistryIngressSecretName }}
+    tls:
+    - hosts:
+      - {{ printf "che-devfile-registry-%s.%s" .Release.Namespace .Values.global.ingressDomain }}
+      secretName: {{ .Values.cheDevfileRegistryIngressSecretName }}
+{{- end -}}

--- a/deploy/kubernetes/che-devfile-registry/templates/service.yaml
+++ b/deploy/kubernetes/che-devfile-registry/templates/service.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: che-devfile-registry
+  name: che-devfile-registry
+spec:
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: che-devfile-registry

--- a/deploy/kubernetes/che-devfile-registry/values.yaml
+++ b/deploy/kubernetes/che-devfile-registry/values.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+cheDevfileRegistryImage: eclipse/che-devfile-registry
+cheDevfileRegistryImagePullPolicy: Always
+cheDevfileRegistryMemoryLimit: 256Mi
+#cheDevfileRegistryIngressSecretName: che-tls
+
+global:
+  ingressDomain: 192.168.99.100.nip.io
+  ingress:
+    class: 'nginx'

--- a/deploy/openshift/che-devfile-registry.yaml
+++ b/deploy/openshift/che-devfile-registry.yaml
@@ -1,0 +1,100 @@
+#
+# Copyright (c) 2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: che-devfile-registry
+objects:
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: che-devfile-registry
+    name: che-devfile-registry
+  spec:
+    replicas: 1
+    selector:
+      app: che-devfile-registry
+      deploymentconfig: che-devfile-registry
+    strategy:
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          app: che-devfile-registry
+          deploymentconfig: che-devfile-registry
+      spec:
+        containers:
+        - image: ${IMAGE}:${IMAGE_TAG}
+          imagePullPolicy: "${PULL_POLICY}"
+          name: che-devfile-registry
+          ports:
+          - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /devfiles/
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /devfiles/
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 3
+          resources:
+            limits:
+              memory: ${MEMORY_LIMIT}
+    triggers:
+    - type: ConfigChange
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: che-devfile-registry
+  spec:
+    ports:
+      - protocol: TCP
+        port: 80
+        targetPort: 8080
+    selector:
+      deploymentconfig: che-devfile-registry
+- apiVersion: v1
+  kind: Route
+  metadata:
+    name: che-devfile-registry
+  spec:
+    to:
+      kind: Service
+      name: che-devfile-registry
+parameters:
+- name: IMAGE
+  value: eclipse/che-devfile-registry
+  displayName: Eclipse Che devfile registry image
+  description: Che devfile registry Docker image. Defaults to eclipse/che-devfile-registry
+- name: IMAGE_TAG
+  value: latest
+  displayName: Eclipse Che devfile registry version
+  description: Eclipse Che devfile registry version which defaults to latest
+- name: MEMORY_LIMIT
+  value: 256Mi
+  displayName: Memory Limit
+  description: Maximum amount of memory the container can use. Defaults 256Mi
+- name: PULL_POLICY
+  value: Always
+  displayName: Eclipse Che devfile registry image pull policy
+  description: Always pull by default. Can be IfNotPresent

--- a/devfiles/.htaccess
+++ b/devfiles/.htaccess
@@ -1,0 +1,1 @@
+DirectoryIndex index.json

--- a/devfiles/che7-preview.yaml
+++ b/devfiles/che7-preview.yaml
@@ -1,0 +1,29 @@
+---
+displayName: Che 7 Preview
+description: Workspace.next sidecars and Theia as IDE
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+name: che7-preview
+components:
+  -
+    type: cheEditor
+    id: eclipse/che-theia/next
+  -
+    type: chePlugin
+    id: eclipse/che-machine-exec-devfile/0.0.1
+  -
+    type: kubernetes
+    referenceContent: |
+      kind: List
+      items:
+        -
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: ws
+          spec:
+            containers:
+            - image: eclipse/che-dev:nightly
+              name: dev
+              resources:
+                limits:
+                  memory: 512Mi

--- a/index.sh
+++ b/index.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+set -e
+
+# Arguments:
+# 1 - folder to search files in
+function buildIndex() {
+    metaInfoFields=('displayName' 'description' 'icon')
+
+    ## search for all devfiles
+    readarray -d '' arr < <(find "$1" -name '*.yaml' -print0)
+    FIRST_LINE=true
+    echo "["
+
+    ## now loop through devfiles
+    for i in "${arr[@]}"
+    do
+        if [ "$FIRST_LINE" = true ] ; then
+            echo "{"
+            FIRST_LINE=false
+        else
+            echo ",{"
+        fi
+
+        for field in "${metaInfoFields[@]}"
+        do
+            value="$(yq r "$i" "$field" | sed 's/^"\(.*\)"$/\1/')"
+            echo "  \"$field\":\"$value\","
+            yq delete -i $i $field
+        done
+
+        echo "  \"links\": {\"self\":\"/$i\" }"
+        echo "}"
+    done
+    echo "]"
+}
+
+buildIndex devfiles


### PR DESCRIPTION
### What does this PR do?
Initialize Che Devfile Registry. Changes are divided into separate commits to make review easier:
1. Add Che 7 Preview Devfile based on the corresponding stack.
Note that devfile in repository contains extra fields (description, displayName, icon) which are copied to index.json and dropped out from devfile on phase of build.
2. Add an ability to build image for Che Devfile Registry.
3. Set up CentOS CI. It contains build script and job will be created after merging this PR. 
4. Add template for deploying Che Devfile Registry to OpenShift.
5. Add helm chart for deploying Che Devfile Registry on Kubernetes.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13353
This is only first PR for setting up Che Devfile Registry and the following changes will be set soon:
- set up circleci to perform bash checks;
- add more Devfiles that are based on Che 7 Stacks;
- make API respond with JSON instead of YAML(should be investigated if needed);

Further improvements:
- add JSON Schema check for devfiles in a repository on docker image phase.

### How to test this PR
Until cico job is not set, the following image may be used for testing `sleshchenko/che-devfile-registry:initial`

![devfile-registry](https://user-images.githubusercontent.com/5887312/58104098-d2c2f080-7bec-11e9-875e-519c48822be8.gif)
