### PR TITLE
Specify home path in java-maven devfile

### DIFF
--- a/devfiles/java-maven/devfile.yaml
+++ b/devfiles/java-maven/devfile.yaml
@@ -17,7 +17,8 @@ components:
       - name: MAVEN_OPTS
         value: "-XX:MaxRAMPercentage=50 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
           -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
-          -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom"
+          -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom
+          -Duser.home=/home/user"
       - name: JAVA_OPTS
         value: "-XX:MaxRAMPercentage=50 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
           -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90


### PR DESCRIPTION
### What does this PR do?
Since OpenShift starts containers with a random UID (which has no username associated with it), maven running on OpenShift cannot figure out where to place the .m2 repository. This PR explicitly sets the -Duser.home parameter to /home/user to match the mounted .m2 volume.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13451