### PR TITLE
Remove memory limit of apache-camel plugin

### DIFF
--- a/devfiles/apache-camel-springboot-che7/devfile.yaml
+++ b/devfiles/apache-camel-springboot-che7/devfile.yaml
@@ -9,7 +9,6 @@ components:
   -
     type: chePlugin
     id: camel-tooling/vscode-apache-camel/0.0.14
-    memoryLimit: 128Mi
   -
     type: chePlugin
     id: redhat/java/0.38.0


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Since we have defined memory limit in [plugin description](https://github.com/eclipse/che-plugin-registry/blob/master/v3/plugins/camel-tooling/vscode-apache-camel/0.0.14/meta.yaml#L16), we don't need to do that in devfile.

This PR should be merged after https://github.com/openshiftio/saas-openshiftio/pull/1308

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13225