### PR TITLE
Update gradle mounted volume path to match dockerfile

### DIFF
--- a/devfiles/java-gradle/devfile.yaml
+++ b/devfiles/java-gradle/devfile.yaml
@@ -20,7 +20,7 @@ components:
     args: ['infinity']
     env:
       - name: GRADLE_USER_HOME
-        value: /home/user/.gradle
+        value: /home/gradle/.gradle
       - name: JAVA_OPTS
         value: "-XX:MaxRAMPercentage=50 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
           -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
@@ -32,14 +32,14 @@ components:
       - name: PS1
         value: "$(echo ${0})\\$ "
       - name: HOME
-        value: /home/user
+        value: /home/gradle
     memoryLimit: 512Mi
     endpoints:
       - name: '8080/tcp'
         port: 8080
     volumes:
       - name: gradle
-        containerPath: /home/user/.gradle
+        containerPath: /home/gradle/.gradle
     mountSources: true
 commands:
   -


### PR DESCRIPTION
### What does this PR do?
Modifies the volume used for the `.gradle` directory to be `/home/gradle/.gradle`. This is necessary because the [dockerfile](https://github.com/keeganwitt/docker-gradle/blob/7c606d205bcf13551f8203e12174c37004383694/jdk8/Dockerfile#L17) used specifies this as a `VOLUME`, which causes issues when that path is not mounted via PVC.

I have tested this devfile and it appears to work (at least, as well as community docker images generally do -- see https://github.com/eclipse/che/issues/13454) but further testing is appreciated.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13384, see [comment](https://github.com/eclipse/che/issues/13384#issuecomment-503175239) for more explanation.