### PR TITLE
Add Java Web devfiles

### DIFF
--- a/devfiles/java-mysql/devfile.yaml
+++ b/devfiles/java-mysql/devfile.yaml
@@ -7,8 +7,7 @@ projects:
     name: web-java-spring-petclinic
     source:
       type: git
-      location: "https://github.com/che-samples/web-java-spring-petclinic.git"
-      branch: mysql
+      location: "https://github.com/spring-projects/spring-petclinic.git"
 components:
   -
     type: chePlugin
@@ -20,25 +19,15 @@ components:
     command: ['sleep']
     args: ['infinity']
     env:
-      - name: MAVEN_CONFIG
-        value: /home/user/.m2
-      - name: MAVEN_OPTS
+      - name: JAVA_OPTS
         value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
           -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
           -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom
           -Duser.home=/home/user"
-      - name: JAVA_OPTS
-        value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
-          -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
-          -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom"
-      - name: JAVA_TOOL_OPTIONS
-        value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
-          -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
-          -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom"
+      - name: MAVEN_OPTS
+        value: $(JAVA_OPTS)
       - name: PS1
         value: $(echo ${0})\\$
-      - name: HOME
-        value: /home/user
     memoryLimit: 512Mi
     endpoints:
       - name: '8080/tcp'
@@ -60,14 +49,13 @@ components:
         value: petclinic
       - name: PS1
         value: $(echo ${0})\\$
-      - name: HOME
-        value: /home/user
     memoryLimit: 256Mi
     endpoints:
       - name: 'db'
         port: 3306
         attributes:
           discoverable: "true"
+          public: "false"
     mountSources: false
 commands:
   -
@@ -76,37 +64,13 @@ commands:
       -
         type: exec
         component: tools
-        command: "mvn -Duser.home=${HOME} clean install"
+        command: "./mvnw clean install"
         workdir: "${CHE_PROJECTS_ROOT}/web-java-spring-petclinic"
-  -
-    name: deploy
+  - name: run webapp
     actions:
       -
         type: exec
         component: tools
-        command: "cp target/*.war ${TOMCAT_HOME}/webapps/ROOT.war"
-        workdir: "${CHE_PROJECTS_ROOT}/web-java-spring-petclinic"
-  -
-    name: start tomcat
-    actions:
-      -
-        type: exec
-        component: tools
-        command: "${TOMCAT_HOME}/bin/catalina.sh run 2>&1"
-        workdir: "${TOMCAT_HOME}"
-  -
-    name: stop tomcat
-    actions:
-      -
-        type: exec
-        component: tools
-        command: "./bin/catalina.sh stop"
-        workdir: "${TOMCAT_HOME}"
-  -
-    name: maven build and deploy
-    actions:
-      -
-        type: exec
-        component: tools
-        command: "mvn -Duser.home=${HOME} clean install && cp target/*.war ${TOMCAT_HOME}/webapps/ROOT.war"
-        workdir: "${CHE_PROJECTS_ROOT}/web-java-spring-petclinic"
+        command: |
+          SPRING_DATASOURCE_URL=jdbc:mysql://db/petclinic SPRING_DATASOURCE_USERNAME=petclinic SPRING_DATASOURCE_PASSWORD=password java -jar target/*.jar --spring.profile.active=mysql
+        workdir: ${CHE_PROJECTS_ROOT}/web-java-spring-petclinic

--- a/devfiles/java-mysql/devfile.yaml
+++ b/devfiles/java-mysql/devfile.yaml
@@ -28,7 +28,7 @@ components:
         value: $(JAVA_OPTS)
       - name: PS1
         value: $(echo ${0})\\$
-    memoryLimit: 512Mi
+    memoryLimit: 700Mi
     endpoints:
       - name: '8080/tcp'
         port: 8080

--- a/devfiles/java-mysql/devfile.yaml
+++ b/devfiles/java-mysql/devfile.yaml
@@ -1,0 +1,112 @@
+---
+apiVersion: 1.0.0
+metadata:
+  name: java-mysql
+projects:
+  -
+    name: web-java-spring-petclinic
+    source:
+      type: git
+      location: "https://github.com/che-samples/web-java-spring-petclinic.git"
+      branch: mysql
+components:
+  -
+    type: chePlugin
+    id: redhat/java/latest
+  -
+    type: dockerimage
+    alias: tools
+    image: registry.centos.org/che-stacks/centos-jdk8
+    command: ['sleep']
+    args: ['infinity']
+    env:
+      - name: MAVEN_CONFIG
+        value: /home/user/.m2
+      - name: MAVEN_OPTS
+        value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
+          -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
+          -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom
+          -Duser.home=/home/user"
+      - name: JAVA_OPTS
+        value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
+          -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
+          -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom"
+      - name: JAVA_TOOL_OPTIONS
+        value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
+          -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
+          -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom"
+      - name: PS1
+        value: $(echo ${0})\\$
+      - name: HOME
+        value: /home/user
+    memoryLimit: 512Mi
+    endpoints:
+      - name: '8080/tcp'
+        port: 8080
+    mountSources: true
+    volumes:
+      - name: m2
+        containerPath: /home/user/.m2
+  -
+    type: dockerimage
+    alias: mysql
+    image: centos/mysql-57-centos7
+    env:
+      - name: MYSQL_USER
+        value: petclinic
+      - name: MYSQL_PASSWORD
+        value: password
+      - name: MYSQL_DATABASE
+        value: petclinic
+      - name: PS1
+        value: $(echo ${0})\\$
+      - name: HOME
+        value: /home/user
+    memoryLimit: 256Mi
+    endpoints:
+      - name: 'db'
+        port: 3306
+        attributes:
+          discoverable: "true"
+    mountSources: false
+commands:
+  -
+    name: maven build
+    actions:
+      -
+        type: exec
+        component: tools
+        command: "mvn -Duser.home=${HOME} clean install"
+        workdir: "${CHE_PROJECTS_ROOT}/web-java-spring-petclinic"
+  -
+    name: deploy
+    actions:
+      -
+        type: exec
+        component: tools
+        command: "cp target/*.war ${TOMCAT_HOME}/webapps/ROOT.war"
+        workdir: "${CHE_PROJECTS_ROOT}/web-java-spring-petclinic"
+  -
+    name: start tomcat
+    actions:
+      -
+        type: exec
+        component: tools
+        command: "${TOMCAT_HOME}/bin/catalina.sh run 2>&1"
+        workdir: "${TOMCAT_HOME}"
+  -
+    name: stop tomcat
+    actions:
+      -
+        type: exec
+        component: tools
+        command: "./bin/catalina.sh stop"
+        workdir: "${TOMCAT_HOME}"
+  -
+    name: maven build and deploy
+    actions:
+      -
+        type: exec
+        component: tools
+        command: "mvn -Duser.home=${HOME} clean install && cp target/*.war ${TOMCAT_HOME}/webapps/ROOT.war"
+        workdir: "${CHE_PROJECTS_ROOT}/web-java-spring-petclinic"

--- a/devfiles/java-mysql/meta.yaml
+++ b/devfiles/java-mysql/meta.yaml
@@ -1,0 +1,6 @@
+---
+displayName: Java MySQL
+description: Default Java MySQL
+tags: ["Java", "Maven", "Spring Boot v2", "MySQL"]
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+globalMemoryLimit: 2930Mi

--- a/devfiles/java-mysql/meta.yaml
+++ b/devfiles/java-mysql/meta.yaml
@@ -1,6 +1,6 @@
 ---
-displayName: Java MySQL
-description: Default Java MySQL
-tags: ["Java", "Maven", "Spring Boot v2", "MySQL"]
+displayName: Java with Spring Boot and MySQL
+description: Java stack with OpenJDK 8, MySQL and Spring Boot Petclinic demo application
+tags: ["Java", "OpenJDK", "Maven", "Spring Boot", "MySQL"]
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 globalMemoryLimit: 2930Mi

--- a/devfiles/java-web-spring/devfile.yaml
+++ b/devfiles/java-web-spring/devfile.yaml
@@ -4,10 +4,10 @@ metadata:
   name: java-web-spring
 projects:
   -
-    name: web-java-spring
+    name: java-web-spring
     source:
       type: git
-      location: "https://github.com/che-samples/web-java-spring.git"
+      location: "https://github.com/spring-projects/spring-petclinic.git"
 components:
   -
     type: chePlugin
@@ -19,26 +19,16 @@ components:
     command: ['sleep']
     args: ['infinity']
     env:
-      - name: MAVEN_CONFIG
-        value: /home/user/.m2
-      - name: MAVEN_OPTS
+      - name: JAVA_OPTS
         value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
           -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
           -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom
           -Duser.home=/home/user"
-      - name: JAVA_OPTS
-        value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
-          -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
-          -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom"
-      - name: JAVA_TOOL_OPTIONS
-        value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
-          -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
-          -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom"
+      - name: MAVEN_OPTS
+        value: $(JAVA_OPTS)
       - name: PS1
         value: $(echo ${0})\\$
-      - name: HOME
-        value: /home/user
-    memoryLimit: 512Mi
+    memoryLimit: 1024Mi
     endpoints:
       - name: '8080/tcp'
         port: 8080
@@ -53,37 +43,12 @@ commands:
       -
         type: exec
         component: tools
-        command: "mvn -Duser.home=${HOME} clean install"
-        workdir: ${CHE_PROJECTS_ROOT}/web-java-spring
-  -
-    name: deploy
+        command: "./mvnw clean install"
+        workdir: ${CHE_PROJECTS_ROOT}/java-web-spring
+  - name: run webapp
     actions:
       -
         type: exec
         component: tools
-        command: "cp target/*.war ${TOMCAT_HOME}/webapps/ROOT.war"
-        workdir: ${CHE_PROJECTS_ROOT}/web-java-spring
-  -
-    name: start tomcat
-    actions:
-      -
-        type: exec
-        component: tools
-        command: "./bin/catalina.sh run 2>&1"
-        workdir: ${TOMCAT_HOME}
-  -
-    name: stop tomcat
-    actions:
-      -
-        type: exec
-        component: tools
-        command: "./bin/catalina.sh stop"
-        workdir: ${TOMCAT_HOME}
-  -
-    name: maven build and deploy
-    actions:
-      -
-        type: exec
-        component: tools
-        command: "mvn -Duser.home=${HOME} clean install && cp target/*.war ${TOMCAT_HOME}/webapps/ROOT.war"
-        workdir: ${CHE_PROJECTS_ROOT}/web-java-spring
+        command: "java -jar target/*.jar"
+        workdir: ${CHE_PROJECTS_ROOT}/java-web-spring

--- a/devfiles/java-web-spring/devfile.yaml
+++ b/devfiles/java-web-spring/devfile.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: 1.0.0
+metadata:
+  name: java-web-spring
+projects:
+  -
+    name: web-java-spring
+    source:
+      type: git
+      location: "https://github.com/che-samples/web-java-spring.git"
+components:
+  -
+    type: chePlugin
+    id: redhat/java/latest
+  -
+    type: dockerimage
+    alias: tools
+    image: registry.centos.org/che-stacks/centos-jdk8
+    command: ['sleep']
+    args: ['infinity']
+    env:
+      - name: MAVEN_CONFIG
+        value: /home/user/.m2
+      - name: MAVEN_OPTS
+        value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
+          -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
+          -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom
+          -Duser.home=/home/user"
+      - name: JAVA_OPTS
+        value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
+          -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
+          -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom"
+      - name: JAVA_TOOL_OPTIONS
+        value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
+          -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
+          -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom"
+      - name: PS1
+        value: $(echo ${0})\\$
+      - name: HOME
+        value: /home/user
+    memoryLimit: 512Mi
+    endpoints:
+      - name: '8080/tcp'
+        port: 8080
+    mountSources: true
+    volumes:
+      - name: m2
+        containerPath: /home/user/.m2
+commands:
+  -
+    name: maven build
+    actions:
+      -
+        type: exec
+        component: tools
+        command: "mvn -Duser.home=${HOME} clean install"
+        workdir: ${CHE_PROJECTS_ROOT}/web-java-spring
+  -
+    name: deploy
+    actions:
+      -
+        type: exec
+        component: tools
+        command: "cp target/*.war ${TOMCAT_HOME}/webapps/ROOT.war"
+        workdir: ${CHE_PROJECTS_ROOT}/web-java-spring
+  -
+    name: start tomcat
+    actions:
+      -
+        type: exec
+        component: tools
+        command: "./bin/catalina.sh run 2>&1"
+        workdir: ${TOMCAT_HOME}
+  -
+    name: stop tomcat
+    actions:
+      -
+        type: exec
+        component: tools
+        command: "./bin/catalina.sh stop"
+        workdir: ${TOMCAT_HOME}
+  -
+    name: maven build and deploy
+    actions:
+      -
+        type: exec
+        component: tools
+        command: "mvn -Duser.home=${HOME} clean install && cp target/*.war ${TOMCAT_HOME}/webapps/ROOT.war"
+        workdir: ${CHE_PROJECTS_ROOT}/web-java-spring

--- a/devfiles/java-web-spring/meta.yaml
+++ b/devfiles/java-web-spring/meta.yaml
@@ -1,0 +1,6 @@
+---
+displayName: Java Web Spring
+description: Default Java Spring Stack
+tags: ["Java", "Maven", "Spring Boot v2"]
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+globalMemoryLimit: 2674Mi

--- a/devfiles/java-web-spring/meta.yaml
+++ b/devfiles/java-web-spring/meta.yaml
@@ -1,6 +1,6 @@
 ---
-displayName: Java Web Spring
-description: Default Java Spring Stack
-tags: ["Java", "Maven", "Spring Boot v2"]
+displayName: Java Spring Boot
+description: Java stack with OpenJDK 8 and Spring Boot Petclinic demo application
+tags: ["Java", "OpenJDK", "Maven", "Spring Boot"]
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 globalMemoryLimit: 2674Mi

--- a/devfiles/java-web-vertx/devfile.yaml
+++ b/devfiles/java-web-vertx/devfile.yaml
@@ -61,5 +61,5 @@ commands:
       -
         type: exec
         component: maven
-        command: "java -jar ./target/*fat.jar"
+        command: "JDBC_URL=jdbc:h2:/tmp/db java -jar ./target/*fat.jar"
         workdir: "${CHE_PROJECTS_ROOT}/java-web-vertx"

--- a/devfiles/java-web-vertx/devfile.yaml
+++ b/devfiles/java-web-vertx/devfile.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: 1.0.0
+metadata:
+  name: java-web-vertx
+projects:
+  -
+    name: java-web-vertx
+    source:
+      type: git
+      location: "https://github.com/che-samples/web-java-vertx"
+components:
+  -
+    type: chePlugin
+    id: redhat/java/latest
+  -
+    type: dockerimage
+    alias: maven
+    image: registry.centos.org/che-stacks/centos-jdk8
+    command: ['sleep']
+    args: ['infinity']
+    env:
+      - name: MAVEN_CONFIG
+        value: /home/user/.m2
+      - name: MAVEN_OPTS
+        value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
+          -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
+          -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom
+          -Duser.home=/home/user"
+      - name: JAVA_OPTS
+        value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
+          -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
+          -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom"
+      - name: JAVA_TOOL_OPTIONS
+        value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
+          -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
+          -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom"
+      - name: PS1
+        value: $(echo ${0})\\$
+      - name: HOME
+        value: /home/user
+    memoryLimit: 512Mi
+    endpoints:
+      - name: '8080/tcp'
+        port: 8080
+    mountSources: true
+    volumes:
+      - name: m2
+        containerPath: /home/user/.m2
+commands:
+  -
+    name: maven build
+    actions:
+      -
+        type: exec
+        component: maven
+        command: "mvn -Duser.home=${HOME} clean install"
+        workdir: "${CHE_PROJECTS_ROOT}/java-web-vertx"
+  -
+    name: run app
+    actions:
+      -
+        type: exec
+        component: maven
+        command: "java -jar ./target/*fat.jar"
+        workdir: "${CHE_PROJECTS_ROOT}/java-web-vertx"

--- a/devfiles/java-web-vertx/devfile.yaml
+++ b/devfiles/java-web-vertx/devfile.yaml
@@ -19,25 +19,15 @@ components:
     command: ['sleep']
     args: ['infinity']
     env:
-      - name: MAVEN_CONFIG
-        value: /home/user/.m2
-      - name: MAVEN_OPTS
+      - name: JAVA_OPTS
         value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
           -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
           -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom
           -Duser.home=/home/user"
-      - name: JAVA_OPTS
-        value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
-          -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
-          -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom"
-      - name: JAVA_TOOL_OPTIONS
-        value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
-          -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
-          -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom"
+      - name: MAVEN_OPTS
+        value: $(JAVA_OPTS)
       - name: PS1
         value: $(echo ${0})\\$
-      - name: HOME
-        value: /home/user
     memoryLimit: 512Mi
     endpoints:
       - name: '8080/tcp'

--- a/devfiles/java-web-vertx/meta.yaml
+++ b/devfiles/java-web-vertx/meta.yaml
@@ -1,0 +1,6 @@
+---
+displayName: Vertx Web
+description: Default Vertx Web Stack
+tags: ["Java", "Maven", "Spring Boot v2", "Vertx"]
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+globalMemoryLimit: 2674Mi

--- a/devfiles/java-web-vertx/meta.yaml
+++ b/devfiles/java-web-vertx/meta.yaml
@@ -1,6 +1,6 @@
 ---
-displayName: Vertx Web
-description: Default Vertx Web Stack
-tags: ["Java", "Maven", "Spring Boot v2", "Vertx"]
+displayName: Java Vert.x
+description: Java stack with OpenJDK 8 and Vert.x demo application
+tags: ["Java", "OpenJDK", "Maven", "Vertx"]
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 globalMemoryLimit: 2674Mi


### PR DESCRIPTION
### What does this PR do?
This PR adds the following samples devfiles:

| | stack | sample |
|-| ----- | ------ |
| :heavy_check_mark: | java-spring-web | https://github.com/che-samples/web-java-spring.git |
| :heavy_check_mark: | java-vertx | https://github.com/vert-x3/vertx-examples |
| :heavy_check_mark: | java-mysql | https://github.com/che-samples/web-java-spring-petclinic |

Notes:
* initially java-postgresql was requested but we do not have (and did not find easily) Java + PostgreSQL sample, and was decided to replace it with stack that we used to have `JAVA + MYSQL`
* Initially, sample from https://github.com/vert-x3/vertx-examples was requested but Devfile do not support `keepDirectory` feature and it was decided to use our old https://github.com/che-samples/web-java-vertx. Also, note that verx container is not provided but an application is run via Spring Boot in jdk container. I tried to use it but that sample has some compatibility issues. It can be improved later and I'll create an issue for that.


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13529