### PR TITLE
Updating codeowners for Che 7 endgame code reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global Owners
+* @vparfonov @l0rd @rhopp @skabashnyuk


### PR DESCRIPTION
Adding @l0rd @rhopp @skabashnyuk as global code reviewers as required by https://github.com/eclipse/che/issues/13637