### PR TITLE
Add NodeJS stack with react realworld app

### DIFF
--- a/devfiles/nodejs-react/devfile.yaml
+++ b/devfiles/nodejs-react/devfile.yaml
@@ -16,6 +16,7 @@ components:
   -
     type: dockerimage
     alias: nodejs
+    # system limit for number of file watchers reached with
     # image: registry.access.redhat.com/ubi8/nodejs-10
     image: registry.centos.org/che-stacks/centos-nodejs
     command: ['sleep']

--- a/devfiles/nodejs-react/devfile.yaml
+++ b/devfiles/nodejs-react/devfile.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: 1.0.0
+metadata:
+  name: nodejs-react
+projects:
+  -
+    name: react-redux-realworld-example-app
+    source:
+      type: git
+      location: "https://github.com/gothinkster/react-redux-realworld-example-app"
+components:
+  -
+    type: chePlugin
+    id: che-incubator/typescript/latest
+    memoryLimit: 512Mi
+  -
+    type: dockerimage
+    alias: nodejs
+    # image: registry.access.redhat.com/ubi8/nodejs-10
+    image: registry.centos.org/che-stacks/centos-nodejs
+    command: ['sleep']
+    args: ['infinity']
+    env:
+      - name: HOME
+        value: /tmp/user
+      - name: PS1
+        value: $(echo ${0})\\$
+    memoryLimit: 512Mi
+    endpoints:
+      - name: 'nodejs'
+        port: 4100
+    mountSources: true
+commands:
+  -
+    name: install all required dependencies
+    actions:
+      - type: exec
+        component: nodejs
+        command: npm install
+        workdir: ${CHE_PROJECTS_ROOT}/react-redux-realworld-example-app
+  -
+    name: start the local server
+    actions:
+      - type: exec
+        component: nodejs
+        command: npm start
+        workdir: ${CHE_PROJECTS_ROOT}/react-redux-realworld-example-app

--- a/devfiles/nodejs-react/devfile.yaml
+++ b/devfiles/nodejs-react/devfile.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: 1.0.0
 metadata:
-  name: nodejs-react
+  name: react
 projects:
   -
     name: react-redux-realworld-example-app

--- a/devfiles/nodejs-react/meta.yaml
+++ b/devfiles/nodejs-react/meta.yaml
@@ -1,0 +1,6 @@
+---
+displayName: React web application
+description: NodeJS 10 stack with React real world application
+tags: ["NodeJS", "React", "Redux", "RealWorld"]
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+globalMemoryLimit: 1686Mi

--- a/devfiles/nodejs-react/meta.yaml
+++ b/devfiles/nodejs-react/meta.yaml
@@ -1,6 +1,6 @@
 ---
-displayName: React web application
-description: NodeJS 10 stack with React real world application
+displayName: NodeJS React Web Application
+description: Stack for developing NodeJS React Web Application
 tags: ["NodeJS", "React", "Redux", "RealWorld"]
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 globalMemoryLimit: 1686Mi


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Adds NodeJS stack with the react realworld example [1]

### Issues
1. It is not possible to use `registry.access.redhat.com/ubi8/nodejs-10` image due to error `system limit for number of file watchers reached` when server starts (`npm start`).

2. `API_ROOT` [2] can't be modified due to issue [3]

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13529

[1] https://github.com/gothinkster/react-redux-realworld-example-app
[2] https://github.com/gothinkster/react-redux-realworld-example-app/blob/master/src/agent.js#L6
[3] https://github.com/gothinkster/react-redux-realworld-example-app/issues/134

