### PR TITLE
che #13813: Pushing centos images to 'eclipse' org on quay.io

### DIFF
--- a/cico_build.sh
+++ b/cico_build.sh
@@ -66,7 +66,7 @@ function deploy() {
     IMAGE="rhel-che-devfile-registry"
   else
     DOCKERFILE="Dockerfile"
-    ORGANIZATION="eclipse-che"
+    ORGANIZATION="eclipse"
     IMAGE="che-devfile-registry"
     # For pushing to quay.io 'eclipse-che' organization we need to use different credentials
     QUAY_USERNAME=${QUAY_ECLIPSE_CHE_USERNAME}


### PR DESCRIPTION
### What does this PR do?
che #13813: Pushing centos images to 'eclipse' org (not 'eclipse-che') on quay.io
It was decided to consolidate all the community images in a single  https://quay.io/organization/eclipse organization

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13813