### PR TITLE
che #13813: Adding missing REGISTRY env var to the nightly ci build

### DIFF
--- a/cico_build_nightly.sh
+++ b/cico_build_nightly.sh
@@ -55,6 +55,7 @@ function tag_push() {
 
 function build_and_push() {
   DOCKERFILE="Dockerfile"
+  REGISTRY="quay.io"
   ORGANIZATION="eclipse"
   IMAGE="che-devfile-registry"
   TAG="nightly"


### PR DESCRIPTION
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
che #13813: Adding missing REGISTRY env var to the nightly ci build

