### PR TITLE
che #13813: Updating docs and scripts to point to the brand-new 'quay.io/eclipse/che-devfile-registry' which is the default one from now on

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://ci.centos.org/buildStatus/icon?job=devtools-che-devfile-registry-build-master/)](https://ci.centos.org/job/devtools-che-devfile-registry-build-master/)
+[![Build Status](https://ci.centos.org/buildStatus/icon?job=devtools-che-devfile-registry-nightly/)](https://ci.centos.org/job/devtools-che-devfile-registry-nightly/)
 
 # Eclipse Che devfile registry
 
@@ -16,14 +17,14 @@ Useful when you change devfile files and rebuild the image.
 Note that the Dockerfiles feature multi-stage build, so it requires Docker of version 17.05 and higher.
 Though you may also just provide the image to the older versions of Docker (ex. on Minishift) by having it build on newer version, and pushing and pulling it from Docker Hub.
 
-`quay.io/openshiftio/che-devfile-registry:latest` image would be rebuilt after each commit in master.
+`quay.io/eclipse/che-devfile-registry` image would be rebuilt after each commit in master with the commit hash as tag e.g. `73967c0`. There is also `quay.io/eclipse/che-devfile-registry:nightly` image which is updated every 24 hours.
 
 ## OpenShift
 You can deploy Che devfile registry on Openshift with command.
 ```
   oc new-app -f deploy/openshift/che-devfile-registry.yaml \
-             -p IMAGE="quay.io/openshiftio/che-devfile-registry" \
-             -p IMAGE_TAG="latest" \
+             -p IMAGE="quay.io/eclipse/che-devfile-registry" \
+             -p IMAGE_TAG="nightly" \
              -p PULL_POLICY="Always"
 ```
 
@@ -53,7 +54,7 @@ helm delete --purge che-devfile-registry
 
 ## Docker
 ```
-docker run -it --rm -p 8080:8080 quay.io/openshiftio/che-devfile-registry
+docker run -it --rm -p 8080:8080 quay.io/eclipse/che-devfile-registry
 ```
 
 ### License

--- a/build.sh
+++ b/build.sh
@@ -8,4 +8,4 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-docker build -t quay.io/openshiftio/che-devfile-registry:latest .
+docker build -t quay.io/eclipse/che-devfile-registry:latest .

--- a/deploy/kubernetes/che-devfile-registry/values.yaml
+++ b/deploy/kubernetes/che-devfile-registry/values.yaml
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-cheDevfileRegistryImage: quay.io/openshiftio/che-devfile-registry
+cheDevfileRegistryImage: quay.io/eclipse/che-devfile-registry
 cheDevfileRegistryImagePullPolicy: Always
 cheDevfileRegistryMemoryLimit: 256Mi
 #cheDevfileRegistryIngressSecretName: che-tls

--- a/deploy/openshift/che-devfile-registry.yaml
+++ b/deploy/openshift/che-devfile-registry.yaml
@@ -83,11 +83,11 @@ objects:
       name: che-devfile-registry
 parameters:
 - name: IMAGE
-  value: quay.io/openshiftio/che-devfile-registry
+  value: quay.io/eclipse/che-devfile-registry
   displayName: Eclipse Che devfile registry image
-  description: Che devfile registry Docker image. Defaults to quay.io/openshiftio/che-devfile-registry
+  description: Che devfile registry Docker image. Defaults to quay.io/eclipse/che-devfile-registry
 - name: IMAGE_TAG
-  value: latest
+  value: nightly
   displayName: Eclipse Che devfile registry version
   description: Eclipse Che devfile registry version which defaults to latest
 - name: MEMORY_LIMIT


### PR DESCRIPTION
### What does this PR do?
Updating docs and scripts to point to the brand-new 'quay.io/eclipse/che-devfile-registry' which is the default one from now on

### What issues does this PR fix or reference?
Related to https://github.com/eclipse/che/issues/13813