### PR TITLE
Fix some references to quay.io/openshiftio repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository holds ready-to-use Devfiles for different languages and technolo
 
 Execute
 ```shell
-docker build --no-cache -t openshiftio/che-devfile-registry .
+docker build --no-cache -t quay.io/eclipse/che-devfile-registry:nightly .
 ```
 Where `--no-cache` is needed to prevent usage of cached layers with devfile registry files.
 Useful when you change devfile files and rebuild the image.
@@ -16,14 +16,14 @@ Useful when you change devfile files and rebuild the image.
 Note that the Dockerfiles feature multi-stage build, so it requires Docker of version 17.05 and higher.
 Though you may also just provide the image to the older versions of Docker (ex. on Minishift) by having it build on newer version, and pushing and pulling it from Docker Hub.
 
-`quay.io/openshiftio/che-devfile-registry:latest` image would be rebuilt after each commit in master.
+`quay.io/eclipse/che-devfile-registry:nightly` image would be rebuilt after each commit in master.
 
 ## OpenShift
 You can deploy Che devfile registry on Openshift with command.
 ```
   oc new-app -f deploy/openshift/che-devfile-registry.yaml \
-             -p IMAGE="quay.io/openshiftio/che-devfile-registry" \
-             -p IMAGE_TAG="latest" \
+             -p IMAGE="quay.io/eclipse/che-devfile-registry" \
+             -p IMAGE_TAG="nightly" \
              -p PULL_POLICY="Always"
 ```
 
@@ -52,8 +52,9 @@ helm delete --purge che-devfile-registry
 ```
 
 ## Docker
+
 ```
-docker run -it --rm -p 8080:8080 quay.io/openshiftio/che-devfile-registry
+docker run -it --rm -p 8080:8080 quay.io/eclipse/che-devfile-registry:nightly
 ```
 
 ### License

--- a/build.sh
+++ b/build.sh
@@ -8,4 +8,4 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-docker build -t quay.io/openshiftio/che-devfile-registry:latest .
+docker build -t quay.io/eclipse/che-devfile-registry:nightly .

--- a/cico_build.sh
+++ b/cico_build.sh
@@ -68,7 +68,7 @@ function deploy() {
     DOCKERFILE="Dockerfile"
     ORGANIZATION="eclipse"
     IMAGE="che-devfile-registry"
-    # For pushing to quay.io 'eclipse-che' organization we need to use different credentials
+    # For pushing to quay.io 'eclipse' organization we need to use different credentials
     QUAY_USERNAME=${QUAY_ECLIPSE_CHE_USERNAME}
     QUAY_PASSWORD=${QUAY_ECLIPSE_CHE_PASSWORD}
   fi
@@ -85,7 +85,7 @@ function deploy() {
   TAG=$(echo "$GIT_COMMIT" | cut -c1-"${DEVSHIFT_TAG_LEN}")
 
   tag_push "${REGISTRY}/${ORGANIZATION}/$IMAGE:$TAG"
-  echo "CICO: Images pushed to 'quay.io/openshiftio', ready to update deployed app"
+  echo "CICO: Image pushed to '${REGISTRY}/${ORGANIZATION}', ready to update deployed app"
 }
 
 function cico_setup() {

--- a/deploy/kubernetes/che-devfile-registry/values.yaml
+++ b/deploy/kubernetes/che-devfile-registry/values.yaml
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-cheDevfileRegistryImage: quay.io/openshiftio/che-devfile-registry
+cheDevfileRegistryImage: quay.io/eclipse/che-devfile-registry:nightly
 cheDevfileRegistryImagePullPolicy: Always
 cheDevfileRegistryMemoryLimit: 256Mi
 #cheDevfileRegistryIngressSecretName: che-tls

--- a/deploy/openshift/che-devfile-registry.yaml
+++ b/deploy/openshift/che-devfile-registry.yaml
@@ -83,13 +83,13 @@ objects:
       name: che-devfile-registry
 parameters:
 - name: IMAGE
-  value: quay.io/openshiftio/che-devfile-registry
+  value: quay.io/eclipse/che-devfile-registry
   displayName: Eclipse Che devfile registry image
-  description: Che devfile registry Docker image. Defaults to quay.io/openshiftio/che-devfile-registry
+  description: Che devfile registry Docker image. Defaults to quay.io/eclipse/che-devfile-registry
 - name: IMAGE_TAG
-  value: latest
+  value: nightly
   displayName: Eclipse Che devfile registry version
-  description: Eclipse Che devfile registry version which defaults to latest
+  description: Eclipse Che devfile registry version which defaults to nightly
 - name: MEMORY_LIMIT
   value: 256Mi
   displayName: Memory Limit


### PR DESCRIPTION
Some leftover of https://github.com/eclipse/che-devfile-registry/pull/33 and https://github.com/eclipse/che-devfile-registry/pull/35

Related to milestone 7.0.0 issue https://github.com/eclipse/che/issues/13813