### PR TITLE
Build and push patched images *after* logging in

### DIFF
--- a/cico_build_nightly.sh
+++ b/cico_build_nightly.sh
@@ -62,14 +62,14 @@ function build_and_push() {
   IMAGE="che-devfile-registry"
   TAG="nightly"
 
-  "${SCRIPT_DIR}"/arbitrary-users-patch/build_images.sh --push
-  echo "CICO: pushed nightly arbitrary-user patched base images"
-
   if [ -n "${QUAY_ECLIPSE_CHE_USERNAME}" ] && [ -n "${QUAY_ECLIPSE_CHE_PASSWORD}" ]; then
     docker login -u "${QUAY_ECLIPSE_CHE_USERNAME}" -p "${QUAY_ECLIPSE_CHE_PASSWORD}" "${REGISTRY}"
   else
     echo "Could not login, missing credentials for pushing to the '${ORGANIZATION}' organization"
   fi
+
+  "${SCRIPT_DIR}"/arbitrary-users-patch/build_images.sh --push
+  echo "CICO: pushed nightly arbitrary-user patched base images"
 
   # Let's build and push images to 'quay.io'
   docker build -t ${IMAGE} -f ${DOCKERFILE} .


### PR DESCRIPTION
### What does this PR do?
Fixes a mistake breaking the nightly build -- we attempt to push before logging into the eclipse quay repo.