### PR TITLE
Update dockerfile patch and make new java devfiles used patched images

### DIFF
--- a/arbitrary-users-patch/Dockerfile
+++ b/arbitrary-users-patch/Dockerfile
@@ -2,7 +2,9 @@ ARG FROM_IMAGE
 FROM ${FROM_IMAGE}
 USER 0
 # Set permissions on /etc/passwd and /home to allow arbitrary users to write
-RUN chmod g=u /etc/passwd /home
+RUN mkdir -p /home/user
+RUN chgrp -R 0 /home
+RUN chmod -R g=u /etc/passwd /home
 COPY [--chown=0:0] entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 

--- a/arbitrary-users-patch/entrypoint.sh
+++ b/arbitrary-users-patch/entrypoint.sh
@@ -6,7 +6,7 @@ if [ ! -d "${HOME}" ]; then
 fi
 
 # Setup $PS1 for a consistent and reasonable prompt
-if [ ! -f "${HOME}"/.bashrc ]; then
+if [ -w "${HOME}" ] && [ ! -f "${HOME}"/.bashrc ]; then
   echo "PS1='\s-\v \w \$ '" > "${HOME}"/.bashrc
 fi
 

--- a/devfiles/java-mysql/devfile.yaml
+++ b/devfiles/java-mysql/devfile.yaml
@@ -15,9 +15,7 @@ components:
   -
     type: dockerimage
     alias: tools
-    image: registry.centos.org/che-stacks/centos-jdk8
-    command: ['sleep']
-    args: ['infinity']
+    image: quay.io/eclipse/che-java8-maven:nightly
     env:
       - name: JAVA_OPTS
         value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
@@ -26,8 +24,6 @@ components:
           -Duser.home=/home/user"
       - name: MAVEN_OPTS
         value: $(JAVA_OPTS)
-      - name: PS1
-        value: $(echo ${0})\\$
     memoryLimit: 700Mi
     endpoints:
       - name: '8080/tcp'
@@ -64,7 +60,7 @@ commands:
       -
         type: exec
         component: tools
-        command: "./mvnw clean install"
+        command: "mvn clean install"
         workdir: "${CHE_PROJECTS_ROOT}/web-java-spring-petclinic"
   - name: run webapp
     actions:

--- a/devfiles/java-web-spring/devfile.yaml
+++ b/devfiles/java-web-spring/devfile.yaml
@@ -15,9 +15,7 @@ components:
   -
     type: dockerimage
     alias: tools
-    image: registry.centos.org/che-stacks/centos-jdk8
-    command: ['sleep']
-    args: ['infinity']
+    image: quay.io/eclipse/che-java8-maven:nightly
     env:
       - name: JAVA_OPTS
         value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
@@ -26,8 +24,6 @@ components:
           -Duser.home=/home/user"
       - name: MAVEN_OPTS
         value: $(JAVA_OPTS)
-      - name: PS1
-        value: $(echo ${0})\\$
     memoryLimit: 1024Mi
     endpoints:
       - name: '8080/tcp'
@@ -43,7 +39,7 @@ commands:
       -
         type: exec
         component: tools
-        command: "./mvnw clean install"
+        command: "mvn clean install"
         workdir: ${CHE_PROJECTS_ROOT}/java-web-spring
   - name: run webapp
     actions:

--- a/devfiles/java-web-vertx/devfile.yaml
+++ b/devfiles/java-web-vertx/devfile.yaml
@@ -15,9 +15,7 @@ components:
   -
     type: dockerimage
     alias: maven
-    image: registry.centos.org/che-stacks/centos-jdk8
-    command: ['sleep']
-    args: ['infinity']
+    image: quay.io/eclipse/che-java8-maven:nightly
     env:
       - name: JAVA_OPTS
         value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
@@ -26,8 +24,6 @@ components:
           -Duser.home=/home/user"
       - name: MAVEN_OPTS
         value: $(JAVA_OPTS)
-      - name: PS1
-        value: $(echo ${0})\\$
     memoryLimit: 512Mi
     endpoints:
       - name: '8080/tcp'


### PR DESCRIPTION
### What does this PR do?
- Update the arbitrary users patch to make sure $HOME is always writable,
fixing issues with some images.

- Update `java-spring`, `java-mysql`, and `java-vertx` to use patched images
    - Update the commands in these images since maven wrapper is incompatible with community maven image
    - The base image used for these stacks is **changed** in this PR: we use `maven:3.6.1-jdk-8` instead of `registry.centos.org/che-stacks/centos-jdk8` to avoid building another patched image.

One change this makes for the spring images is changing the command to **not** use the maven wrapper. This wrapper is intended to make it easier to use maven (https://github.com/takari/maven-wrapper/) but appears to not be necessary for the image we are using. Additionally the wrapper is incompatible with the maven community image on OpenShift, since the community image defines `$MAVEN_CONFIG=/root/.m2`, and the wrapper appears to reuse this env var for (undocumented, afaict) reasons: https://github.com/takari/maven-wrapper/blob/master/mvnw#L301

### What issues does this PR fix or reference?
Part of https://github.com/eclipse/che/issues/13454, https://github.com/redhat-developer/rh-che/issues/1455, some issues raised in #38 (gradle home not writable)

### Tested images:

- `java-vertx`, `java-spring`, `java-mysql`: Everything works except:
   1. Issue https://github.com/eclipse/che/issues/13938 is present (in patched and current master images -- i.e. this PR does not fix this issue)
   2. As in some other stacks, a `.bashrc` already exists so these stacks get an ugly prompt (including workspace ID)

- `java-gradle`: This PR fixes the `/home/gradle` directory not being writable

- `php-simple`: This PR fixes the `/home/user` directory not being writable.