### PR TITLE
Add task to debug django app remotely

### DIFF
--- a/devfiles/python-django/devfile.yaml
+++ b/devfiles/python-django/devfile.yaml
@@ -7,7 +7,7 @@ projects:
     name: django-realworld-example-app
     source:
       type: git
-      location: "https://github.com/gothinkster/django-realworld-example-app"
+      location: "https://github.com/che-samples/django-realworld-example-app"
 components:
   -
     type: chePlugin
@@ -24,12 +24,12 @@ components:
     mountSources: true
 commands:
   -
-    name: install requirements
+    name: install dependencies
     actions:
       -
         type: exec
         component: python
-        command: pip install -r requirements.txt
+        command: pip install -r requirements.txt && pip install ptvsd
         workdir: ${CHE_PROJECTS_ROOT}/django-realworld-example-app
   -
     name: migrate
@@ -40,18 +40,40 @@ commands:
         command: python manage.py migrate
         workdir: ${CHE_PROJECTS_ROOT}/django-realworld-example-app
   -
-    name: patch resources
-    actions:
-      -
-        type: exec
-        component: python
-        command: sed -i "s/ALLOWED_HOSTS = \[\]/ALLOWED_HOSTS = \['*'\]/g" conduit/settings.py
-        workdir: ${CHE_PROJECTS_ROOT}/django-realworld-example-app
-  -
     name: run server
     actions:
       -
         type: exec
         component: python
-        command: python manage.py runserver 0.0.0.0:7000
+        command: export DEBUG_MODE=False && python manage.py runserver 0.0.0.0:7000
         workdir: ${CHE_PROJECTS_ROOT}/django-realworld-example-app
+  -
+    name: run server in debug mode
+    actions:
+      -
+        type: exec
+        component: python
+        command: export DEBUG_MODE=True && python manage.py runserver 0.0.0.0:7000 --noreload --nothreading
+        workdir: ${CHE_PROJECTS_ROOT}/django-realworld-example-app
+  -
+    name: debug
+    actions:
+    - type: vscode-launch
+      referenceContent: >
+        {
+        "version": "0.2.0",
+        "configurations": [
+          {
+            "name": "Python: Remote Attach",
+            "type": "python",
+            "request": "attach",
+            "port": 5678,
+            "host": "0.0.0.0",
+            "pathMappings": [
+              {
+                  "localRoot": "${workspaceFolder}",
+                  "remoteRoot": "${workspaceFolder}"
+              }
+            ]
+          }]
+        }


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

### What does this PR do?
* django application was forked into [1]
* `ptsvd` [2] injected into the sources [3].
* added task to run server in debug mode
* added configuration to debug django app remotely 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13816

[1] https://github.com/che-samples/django-realworld-example-app
[2] https://pypi.org/project/ptvsd/
[3] https://github.com/che-samples/django-realworld-example-app/blob/master/manage.py#L8-L11

![Screenshot from 2019-07-21 05-05-48](https://user-images.githubusercontent.com/1640675/61586124-4a71b500-ab75-11e9-96bf-ed05ea8bb5af.png)
