### PR TITLE
Update angular stack to use non-alpine image

### DIFF
--- a/arbitrary-users-patch/base_images
+++ b/arbitrary-users-patch/base_images
@@ -5,6 +5,6 @@ che-java11-gradle       gradle:5.2.1-jdk11
 che-java11-maven        maven:3.6.0-jdk-11
 che-java8-maven         maven:3.6.1-jdk-8
 che-dotnet-2.2          mcr.microsoft.com/dotnet/core/sdk:2.2-stretch
-che-nodejs10-alpine     node:10.16-alpine
+che-nodejs10-community  node:10.16
 che-nodejs10-ubi        registry.access.redhat.com/ubi8/nodejs-10
 che-nodejs8-centos      registry.centos.org/che-stacks/centos-nodejs

--- a/devfiles/angular/devfile.yaml
+++ b/devfiles/angular/devfile.yaml
@@ -15,14 +15,7 @@ components:
   -
     type: dockerimage
     alias: nodejs
-    image: node:10.16-alpine
-    command: ['tail']
-    args: ['-f', '/dev/null']
-    env:
-      - name: HOME
-        value: /projects
-      - name: PS1
-        value: $(echo ${0})\\$
+    image: quay.io/eclipse/che-nodejs10-community:nightly
     memoryLimit: 1Gi
     endpoints:
       - name: 'angular'


### PR DESCRIPTION
### What does this PR do?
Add new patched image (`che-nodejs10-community`) to replace `node:10.16-alpine` for the angular devfile (see discussion https://github.com/eclipse/che-devfile-registry/pull/38#issuecomment-513309951). I've tested the devfile on our dev-cluster deployment and there seem to be no issues (except `yarn install` failing once)

#### Testing: 
Use this [devfile](http://che-devfile-registry-eclipse-che.devtools-dev.ext.devshift.net/devfiles/angular/devfile.yaml)

### What issues does this PR fix or reference?
Che 7.0.0 blocker: https://github.com/eclipse/che/issues/13454