### PR TITLE
Set back lower memory limits to have stack working by default on

### DIFF
--- a/devfiles/apache-camel-springboot/devfile.yaml
+++ b/devfiles/apache-camel-springboot/devfile.yaml
@@ -16,9 +16,11 @@ components:
   -
     type: chePlugin
     id: camel-tooling/vscode-apache-camel/latest
+    memoryLimit: 200Mi
   -
     type: chePlugin
     id: redhat/java/latest
+    memoryLimit: 1400Mi
   -
     type: dockerimage
     alias: maven


### PR DESCRIPTION
che.openshift.io eclipse/che#13832

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?


### What issues does this PR fix or reference?
