### PR TITLE
Remove debug task in Camel stack eclipse/che#14003

### DIFF
--- a/devfiles/apache-camel-springboot/devfile.yaml
+++ b/devfiles/apache-camel-springboot/devfile.yaml
@@ -61,10 +61,3 @@ commands:
       component: maven
       command: mvn spring-boot:run -DskipTests
       workdir: ${CHE_PROJECTS_ROOT}/fuse-rest-http-booster
-  -
-    name: run and debug the services
-    actions:
-      - type: exec
-        component: maven
-        command: mvn spring-boot:run -DskipTests -Drun.jvmArguments="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005"
-        workdir: ${CHE_PROJECTS_ROOT}/fuse-rest-http-booster


### PR DESCRIPTION
- cannot make it working even when attaching manually the Java debugger
afterwise
- Debug is available through CodeLens on the Application Java class
- no other devfiles are providing this kind of debug task

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?


### What issues does this PR fix or reference?
