### PR TITLE
Fixed java-web-spring quotas to be able to run on OSIO

### DIFF
--- a/devfiles/java-web-spring/devfile.yaml
+++ b/devfiles/java-web-spring/devfile.yaml
@@ -12,6 +12,7 @@ components:
   -
     type: chePlugin
     id: redhat/java/latest
+    memoryLimit: 1512Mi
   -
     type: dockerimage
     alias: tools
@@ -24,7 +25,7 @@ components:
           -Duser.home=/home/user"
       - name: MAVEN_OPTS
         value: $(JAVA_OPTS)
-    memoryLimit: 1024Mi
+    memoryLimit: 768Mi
     endpoints:
       - name: '8080/tcp'
         port: 8080

--- a/devfiles/java-web-spring/meta.yaml
+++ b/devfiles/java-web-spring/meta.yaml
@@ -3,4 +3,4 @@ displayName: Java Spring Boot
 description: Java stack with OpenJDK 8 and Spring Boot Petclinic demo application
 tags: ["Java", "OpenJDK", "Maven", "Spring Boot"]
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
-globalMemoryLimit: 2674Mi
+globalMemoryLimit: 3Gi


### PR DESCRIPTION
### What does this PR do?
This PR fixes the Java Springboot devfile memory quotas in order to be able to run the image on OSIO

### What issues does this PR fix or reference?
Issue: https://github.com/redhat-developer/che-functional-tests/issues/556