### PR TITLE
Add debug configurations to java server devfiles

### DIFF
--- a/devfiles/apache-camel-springboot/devfile.yaml
+++ b/devfiles/apache-camel-springboot/devfile.yaml
@@ -63,3 +63,26 @@ commands:
       component: maven
       command: mvn spring-boot:run -DskipTests
       workdir: ${CHE_PROJECTS_ROOT}/fuse-rest-http-booster
+  -
+    name: run the services (debugging enabled)
+    actions:
+      - type: exec
+        component: maven
+        command: mvn spring-boot:run -DskipTests -Drun.jvmArguments="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005"
+        workdir: ${CHE_PROJECTS_ROOT}/fuse-rest-http-booster
+  -
+    name: Debug remote java application
+    actions:
+      - type: vscode-launch
+        referenceContent: |
+          {
+          "version": "0.2.0",
+          "configurations": [
+            {
+              "type": "java",
+              "name": "Debug (Attach) - Remote",
+              "request": "attach",
+              "hostName": "localhost",
+              "port": 5005
+            }]
+          }

--- a/devfiles/java-mysql/devfile.yaml
+++ b/devfiles/java-mysql/devfile.yaml
@@ -70,7 +70,12 @@ commands:
         type: exec
         component: tools
         command: |
-          SPRING_DATASOURCE_URL=jdbc:mysql://db/petclinic SPRING_DATASOURCE_USERNAME=petclinic SPRING_DATASOURCE_PASSWORD=password java -jar -Dspring.profiles.active=mysql target/*.jar
+          SPRING_DATASOURCE_URL=jdbc:mysql://db/petclinic \
+          SPRING_DATASOURCE_USERNAME=petclinic \
+          SPRING_DATASOURCE_PASSWORD=password \
+          java -jar -Dspring.profiles.active=mysql \
+          -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 \
+          target/*.jar
         workdir: ${CHE_PROJECTS_ROOT}/web-java-spring-petclinic
   -
     name: prepare database
@@ -81,3 +86,18 @@ commands:
       command: |
         /opt/rh/rh-mysql57/root/usr/bin/mysql -u root < ${CHE_PROJECTS_ROOT}/web-java-spring-petclinic/src/main/resources/db/mysql/schema.sql &&
         echo -e "\e[32mDone.\e[0m Database petclinic was configured!"
+  - name: Debug remote java application
+    actions:
+      - type: vscode-launch
+        referenceContent: |
+          {
+          "version": "0.2.0",
+          "configurations": [
+            {
+              "type": "java",
+              "name": "Debug (Attach) - Remote",
+              "request": "attach",
+              "hostName": "localhost",
+              "port": 5005
+            }]
+          }

--- a/devfiles/java-web-spring/devfile.yaml
+++ b/devfiles/java-web-spring/devfile.yaml
@@ -46,5 +46,22 @@ commands:
       -
         type: exec
         component: tools
-        command: "java -jar target/*.jar"
+        command: |
+          java -jar -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 \
+          target/*.jar
         workdir: ${CHE_PROJECTS_ROOT}/java-web-spring
+  - name: Debug remote java application
+    actions:
+      - type: vscode-launch
+        referenceContent: |
+          {
+          "version": "0.2.0",
+          "configurations": [
+            {
+              "type": "java",
+              "name": "Debug (Attach) - Remote",
+              "request": "attach",
+              "hostName": "localhost",
+              "port": 5005
+            }]
+          }

--- a/devfiles/java-web-vertx/devfile.yaml
+++ b/devfiles/java-web-vertx/devfile.yaml
@@ -47,5 +47,23 @@ commands:
       -
         type: exec
         component: maven
-        command: "JDBC_URL=jdbc:h2:/tmp/db java -jar ./target/*fat.jar"
+        command: |
+          JDBC_URL=jdbc:h2:/tmp/db \
+          java -jar -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 \
+          ./target/*fat.jar
         workdir: "${CHE_PROJECTS_ROOT}/java-web-vertx"
+  - name: Debug remote java application
+    actions:
+      - type: vscode-launch
+        referenceContent: |
+          {
+          "version": "0.2.0",
+          "configurations": [
+            {
+              "type": "java",
+              "name": "Debug (Attach) - Remote",
+              "request": "attach",
+              "hostName": "localhost",
+              "port": 5005
+            }]
+          }


### PR DESCRIPTION
### What does this PR do?
Sets up java-spring and java-vertx devfiles to support debugging.

- Adds a default debug config to each devfile so that clicking "Start debugging" works out of the box
- Modifies "run app" commands to start with debugging enabled

With these changes, the flow of "run webapp" -> "Start debugging" works without additional configuration.

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/1434 (although this is not an osio-specific issue)