### PR TITLE
Make devfile endpoints match their sample apps

### DIFF
--- a/devfiles/go/devfile.yaml
+++ b/devfiles/go/devfile.yaml
@@ -28,6 +28,9 @@ components:
       # replicate the GOCACHE from the plugin, even though the cache is not shared
       # between the two
       value: /tmp/.cache
+  endpoints:
+    - name: '8080/tcp'
+      port: 8080
   memoryLimit: 512Mi
   mountSources: true
 commands:

--- a/devfiles/java-gradle/devfile.yaml
+++ b/devfiles/java-gradle/devfile.yaml
@@ -30,9 +30,6 @@ components:
       - name: HOME
         value: /home/gradle
     memoryLimit: 512Mi
-    endpoints:
-      - name: '8080/tcp'
-        port: 8080
     volumes:
       - name: gradle
         containerPath: /home/gradle/.gradle

--- a/devfiles/java-maven/devfile.yaml
+++ b/devfiles/java-maven/devfile.yaml
@@ -33,9 +33,6 @@ components:
           -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
           -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom"
     memoryLimit: 512Mi
-    endpoints:
-      - name: '8080/tcp'
-        port: 8080
     mountSources: true
     volumes:
       - name: m2

--- a/devfiles/php-laravel/devfile.yaml
+++ b/devfiles/php-laravel/devfile.yaml
@@ -23,8 +23,8 @@ components:
   image: quay.io/eclipse/che-php-7:nightly
   memoryLimit: 512Mi
   endpoints:
-  - name: '8080/tcp'
-    port: 8080
+  - name: '8000/tcp'
+    port: 8000
   mountSources: true
   volumes:
     - name: composer

--- a/devfiles/php-symfony/devfile.yaml
+++ b/devfiles/php-symfony/devfile.yaml
@@ -23,8 +23,8 @@ components:
   image: quay.io/eclipse/che-php-7:nightly
   memoryLimit: 512Mi
   endpoints:
-  - name: '8080/tcp'
-    port: 8080
+  - name: '8000/tcp'
+    port: 8000
   mountSources: true
   volumes:
     - name: composer

--- a/devfiles/php-web-simple/devfile.yaml
+++ b/devfiles/php-web-simple/devfile.yaml
@@ -23,6 +23,9 @@ components:
   image: quay.io/eclipse/che-php-7:nightly
   memoryLimit: 512Mi
   mountSources: true
+  endpoints:
+    - name: '8080/tcp'
+      port: 8080
   volumes:
     - name: composer
       containerPath: "/home/user/.composer"


### PR DESCRIPTION
### What does this PR do?
Update devfiles so that exposed ports match those used by the sample app:
- golang: add port `8080`
- java-gradle: remove unused port (simple console app)
- java-maven: remove unused port (simple console app)
- php-laravel: update port to `8000` (instead of `8080`)
- php-symfony: update port to `8000` (instead of `8080`)
- php-web-simple: Add endpoint for port `8080`

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/1434 (though not osio-specific)