### PR TITLE
Add debug config and stop command for go devfile

### DIFF
--- a/devfiles/go/devfile.yaml
+++ b/devfiles/go/devfile.yaml
@@ -5,7 +5,7 @@ metadata:
 projects:
 -
   name: example
-  source: 
+  source:
     type: git
     location: https://github.com/golang/example.git
   clonePath: src/github.com/golang/example/
@@ -38,9 +38,33 @@ commands:
     component: go-cli
     command: go get -d && go run main.go
     workdir: ${CHE_PROJECTS_ROOT}/src/github.com/golang/example/outyet
-- name: test outyet
+-
+  name: stop outyet
+  actions:
+  - type: exec
+    component: go-cli
+    command: kill $(pidof go)
+-
+  name: test outyet
   actions:
   - type: exec
     component: go-cli
     command: go test
     workdir: ${CHE_PROJECTS_ROOT}/src/github.com/golang/example/outyet
+-
+  name: Debug current file
+  actions:
+  - type: vscode-launch
+    referenceContent: |
+      {
+        "version": "0.2.0",
+        "configurations": [
+          {
+            "name": "Debug current file",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${fileDirname}",
+          },
+        ]
+      }


### PR DESCRIPTION
### What does this PR do?
Improves the go devfile:
- Adds a default debug config that makes it easier to debug the current file.
- Adds "Stop outyet" task, since otherwise stopping the server either requires executing `kill` in a terminal or sending `ctrl+C` to the `run outyet` task's tab (which is entirely empty)
  - Also stopping the running task is necessary to start debugging

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/1434 (Debugging working is in the acceptance criteria)