### PR TITLE
Add debug configuration to node-express devfile

### DIFF
--- a/devfiles/nodejs/devfile.yaml
+++ b/devfiles/nodejs/devfile.yaml
@@ -24,6 +24,13 @@ components:
     mountSources: true
 commands:
   -
+    name: download dependencies
+    actions:
+      - type: exec
+        component: nodejs
+        command: npm install
+        workdir: ${CHE_PROJECTS_ROOT}/nodejs-web-app/app
+  -
     name: run the web app
     actions:
       - type: exec

--- a/devfiles/nodejs/devfile.yaml
+++ b/devfiles/nodejs/devfile.yaml
@@ -30,3 +30,29 @@ commands:
         component: nodejs
         command: nodemon app.js
         workdir: ${CHE_PROJECTS_ROOT}/nodejs-web-app/app
+  -
+    name: run the web app (debugging enabled)
+    actions:
+      - type: exec
+        component: nodejs
+        command: nodemon --inspect app.js
+        workdir: ${CHE_PROJECTS_ROOT}/nodejs-web-app/app
+  -
+    name: Attach remote debugger
+    actions:
+    - type: vscode-launch
+      referenceContent: |
+        {
+          "version": "0.2.0",
+          "configurations": [
+            {
+              "type": "node",
+              "request": "attach",
+              "name": "Attach to Remote",
+              "address": "localhost",
+              "port": 9229,
+              "localRoot": "${workspaceFolder}",
+              "remoteRoot": "#{workspaceFolder}"
+            }
+          ]
+        }


### PR DESCRIPTION
### What does this PR do?
Adds configuration to the node-express devfile to allow easier debugging setup:
- Adds task to launch with `--inspect` flag
- Adds debug config so that `F5` connects to running server.

### What issues does this PR fix or reference?
redhat-developer/rh-che#1434 (Debugging working is in the acceptance criteria)