### PR TITLE
Update meta.yamls to use Mi instead of Gi

### DIFF
--- a/devfiles/java-mysql/meta.yaml
+++ b/devfiles/java-mysql/meta.yaml
@@ -3,4 +3,4 @@ displayName: Java with Spring Boot and MySQL
 description: Java stack with OpenJDK 8, MySQL and Spring Boot Petclinic demo application
 tags: ["Java", "OpenJDK", "Maven", "Spring Boot", "MySQL"]
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
-globalMemoryLimit: 3Gi
+globalMemoryLimit: 3072Mi

--- a/devfiles/java-web-spring/meta.yaml
+++ b/devfiles/java-web-spring/meta.yaml
@@ -3,4 +3,4 @@ displayName: Java Spring Boot
 description: Java stack with OpenJDK 8 and Spring Boot Petclinic demo application
 tags: ["Java", "OpenJDK", "Maven", "Spring Boot"]
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
-globalMemoryLimit: 3Gi
+globalMemoryLimit: 3072Mi


### PR DESCRIPTION
### What does this PR do?
Workaround for issue https://github.com/eclipse/che/issues/14096

Devfile `meta.yaml`s which specify `Gi` in their `globalMemoryLimit` display as `0Gi` in the stacks tab.

![Screenshot from 2019-08-01 09-24-20](https://user-images.githubusercontent.com/16168279/62297012-55162f00-b43e-11e9-8d06-4e3b1444084b.png)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14096