### PR TITLE
removing '-Duser.home=/home/user' workaround since '/home/user' exists and setup correctly

### DIFF
--- a/devfiles/java-maven/devfile.yaml
+++ b/devfiles/java-maven/devfile.yaml
@@ -47,7 +47,7 @@ commands:
       -
         type: exec
         component: maven
-        command: "mvn -Duser.home=${HOME} clean install"
+        command: "mvn clean install"
         workdir: ${CHE_PROJECTS_ROOT}/console-java-simple
   -
     name: maven build and run
@@ -55,5 +55,5 @@ commands:
       -
         type: exec
         component: maven
-        command: "mvn -Duser.home=${HOME} clean install && java -jar ./target/*.jar"
+        command: "mvn clean install && java -jar ./target/*.jar"
         workdir: ${CHE_PROJECTS_ROOT}/console-java-simple


### PR DESCRIPTION
### What does this PR do?
Removing '-Duser.home=/home/user' workaround since '/home/user' exists and setup correctly

### What issues does this PR fix or reference?
related to https://github.com/redhat-developer/rh-che/issues/1434