### PR TITLE
use generateName instead of just name

### DIFF
--- a/devfiles/angular/devfile.yaml
+++ b/devfiles/angular/devfile.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: 1.0.0
 metadata:
-  name: angular
+  generateName: angular-
 projects:
   -
     name: angular-realworld-example-app

--- a/devfiles/apache-camel-springboot/devfile.yaml
+++ b/devfiles/apache-camel-springboot/devfile.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: 1.0.0
 metadata:
-  name: apache-camel-springboot
+  generateName: apache-camel-springboot-
 projects:
   -
     name: fuse-rest-http-booster

--- a/devfiles/dotnet/devfile.yaml
+++ b/devfiles/dotnet/devfile.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: 1.0.0
 metadata:
-  name: dotnet
+  generateName: dotnet-
 projects:
   -
     name: dotnet-web-simple

--- a/devfiles/go/devfile.yaml
+++ b/devfiles/go/devfile.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: 1.0.0
 metadata:
-  name: golang
+  generateName: golang-
 projects:
 -
   name: example

--- a/devfiles/java-gradle/devfile.yaml
+++ b/devfiles/java-gradle/devfile.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: 1.0.0
 metadata:
-  name: java-gradle
+  generateName: java-gradle-
 projects:
   -
     name: console-java-simple

--- a/devfiles/java-maven/devfile.yaml
+++ b/devfiles/java-maven/devfile.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: 1.0.0
 metadata:
-  name: java-maven
+  generateName: java-maven-
 projects:
   -
     name: console-java-simple

--- a/devfiles/java-mysql/devfile.yaml
+++ b/devfiles/java-mysql/devfile.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: 1.0.0
 metadata:
-  name: java-mysql
+  generateName: java-mysql-
 projects:
   -
     name: web-java-spring-petclinic

--- a/devfiles/java-web-spring/devfile.yaml
+++ b/devfiles/java-web-spring/devfile.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: 1.0.0
 metadata:
-  name: java-web-spring
+  generateName: java-web-spring-
 projects:
   -
     name: java-web-spring

--- a/devfiles/java-web-vertx/devfile.yaml
+++ b/devfiles/java-web-vertx/devfile.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: 1.0.0
 metadata:
-  name: java-web-vertx
+  generateName: java-web-vertx-
 projects:
   -
     name: java-web-vertx

--- a/devfiles/nodejs-mongo/devfile.yaml
+++ b/devfiles/nodejs-mongo/devfile.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: 1.0.0
 metadata:
-  name: nodejs-mongo
+  generateName: nodejs-mongo-
 projects:
   -
     name: nodejs-mongodb-app

--- a/devfiles/nodejs-react/devfile.yaml
+++ b/devfiles/nodejs-react/devfile.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: 1.0.0
 metadata:
-  name: react
+  generateName: react-
 projects:
   -
     name: react-redux-realworld-example-app

--- a/devfiles/nodejs/devfile.yaml
+++ b/devfiles/nodejs/devfile.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: 1.0.0
 metadata:
-  name: nodejs
+  generateName: nodejs-
 projects:
   -
     name: nodejs-web-app

--- a/devfiles/php-laravel/devfile.yaml
+++ b/devfiles/php-laravel/devfile.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: 1.0.0
 metadata:
-  name: php-laravel
+  generateName: php-laravel-
 projects:
 -
   name: laravel-realworld-example-app

--- a/devfiles/php-mysql/devfile.yaml
+++ b/devfiles/php-mysql/devfile.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: 1.0.0
 metadata:
-  name: php-mysql
+  generateName: php-mysql-
 projects:
 -
   name: crud-php

--- a/devfiles/php-symfony/devfile.yaml
+++ b/devfiles/php-symfony/devfile.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: 1.0.0
 metadata:
-  name: php-symfony
+  generateName: php-symfony-
 projects:
 -
   name: symfony-demo-application

--- a/devfiles/php-web-simple/devfile.yaml
+++ b/devfiles/php-web-simple/devfile.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: 1.0.0
 metadata:
-  name: php-web-simple
+  generateName: php-web-simple-
 projects:
 -
     name: php-web-simple

--- a/devfiles/python-django/devfile.yaml
+++ b/devfiles/python-django/devfile.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: 1.0.0
 metadata:
-  name: python-django
+  generateName: python-django-
 projects:
   -
     name: django-realworld-example-app

--- a/devfiles/python/devfile.yaml
+++ b/devfiles/python/devfile.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: 1.0.0
 metadata:
-  name: python
+  generateName: python-
 projects:
   -
     name: python-hello-world


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

### What does this PR do?
updates devfiles to use `generateName` instead of just name.
Targeted to v7.1.0

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13794
merge after this PR https://github.com/eclipse/che/pull/14157 !!!