### PR TITLE
Add command to configure DocumentRoot in php devfiles

### DIFF
--- a/devfiles/php-mysql/devfile.yaml
+++ b/devfiles/php-mysql/devfile.yaml
@@ -63,9 +63,26 @@ commands:
     component: php
     command: "service apache2 stop"
 -
+  name: Restart Apache Web Server
+  actions:
+  - type: exec
+    component: php
+    command: "service apache2 restart"
+-
   name: Configure database
   actions:
   - type: exec
     component: php
     command: "sed -i 's/localhost/127.0.0.1/g' config.php && php install.php"
     workdir: ${CHE_PROJECTS_ROOT}/crud-php
+-
+  name: Configure Apache Web Server DocumentRoot
+  actions:
+  - type: exec
+    component: php
+    command: |
+      if grep -q '/projects$' /etc/apache2/sites-available/000-default.conf; then
+        sed -i 's|DocumentRoot /projects|DocumentRoot /projects/crud-php/public|' /etc/apache2/sites-available/000-default.conf
+      else
+        echo "DocumentRoot already configured!"
+      fi

--- a/devfiles/php-web-simple/devfile.yaml
+++ b/devfiles/php-web-simple/devfile.yaml
@@ -33,20 +33,31 @@ components:
       containerPath: "/home/user/.symfony"
 commands:
 -
-    name: Start Apache Web Server
-    actions:
+  name: Start Apache Web Server
+  actions:
     - type: exec
       component: php
       command: "service apache2 start"
 -
-    name: Stop Apache Web Server
-    actions:
+  name: Stop Apache Web Server
+  actions:
     - type: exec
       component: php
       command: "service apache2 stop"
 -
-    name: Restart Apache Web Server
-    actions:
+  name: Restart Apache Web Server
+  actions:
     - type: exec
       component: php
       command: "service apache2 restart"
+-
+  name: Configure Apache Web Server DocumentRoot
+  actions:
+    - type: exec
+      component: php
+      command: |
+        if grep -q '/projects$' /etc/apache2/sites-available/000-default.conf; then
+          sed -i 's|DocumentRoot /projects|DocumentRoot /projects/php-web-simple|' /etc/apache2/sites-available/000-default.conf
+        else
+          echo "DocumentRoot already configured!"
+        fi


### PR DESCRIPTION
### What does this PR do?
Adds a command to simpler php devfiles to configure `DocumentRoot` and avoid showing an index page when the application is launched.

Without PR:
![Screenshot from 2019-08-09 10-10-54](https://user-images.githubusercontent.com/16168279/62791840-03078600-ba9c-11e9-921b-14287d54b1cc.png)

With PR (after configure task has been executed)
![Screenshot from 2019-08-09 10-47-19](https://user-images.githubusercontent.com/16168279/62791860-0ef34800-ba9c-11e9-8980-c8cc244ae092.png)


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13964