### PR TITLE
#14076 don't need yq; clean up shell scripts and Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,11 @@ RUN apk add --no-cache bash
 COPY .htaccess README.md *.sh /build/
 COPY /devfiles /build/devfiles
 WORKDIR /build/
-RUN ./check_mandatory_fields.sh devfiles
-RUN ./index.sh > /build/devfiles/index.json
+RUN ./check_mandatory_fields.sh devfiles && \
+    ./index.sh devfiles > /build/devfiles/index.json
 
 FROM registry.centos.org/centos/httpd-24-centos7
-RUN mkdir /var/www/html/devfiles
+RUN mkdir -p /var/www/html/devfiles
 COPY --from=builder /build/ /var/www/html/
 USER 0
 RUN chmod -R g+rwX /var/www/html/devfiles

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -12,23 +12,22 @@ RUN apk add --no-cache bash
 COPY .htaccess README.md *.sh /build/
 COPY /devfiles /build/devfiles
 WORKDIR /build/
-RUN ./check_mandatory_fields.sh devfiles
-RUN ./index.sh > /build/devfiles/index.json
+RUN ./check_mandatory_fields.sh devfiles && \
+    ./index.sh devfiles > /build/devfiles/index.json
 
 FROM quay.io/openshiftio/rhel-base-httpd:latest
 
-RUN sed -i -e "s,Listen 80,Listen 8080," /etc/httpd/conf/httpd.conf
-RUN sed -i -e "s,logs/error_log,/dev/stderr," /etc/httpd/conf/httpd.conf
-RUN sed -i -e "s,logs/access_log,/dev/stdout," /etc/httpd/conf/httpd.conf
-RUN sed -i -e "s,AllowOverride None,AllowOverride All," /etc/httpd/conf/httpd.conf
-
 EXPOSE 80
 
-# the htpasswd file may be periodically replaced during run
-RUN chmod a+rwX            /etc/httpd/conf
-RUN chmod a+rwX            /run/httpd
+RUN sed -e "s,Listen 80,Listen 8080," \
+    -e "s,logs/error_log,/dev/stderr," \
+    -e "s,logs/access_log,/dev/stdout," \
+    -e "s,AllowOverride None,AllowOverride All," \
+    -i /etc/httpd/conf/httpd.conf && \
+    # the htpasswd file may be periodically replaced during run
+    chmod a+rwX /etc/httpd/conf /run/httpd && \
+    mkdir -p /var/www/html/devfiles
 
-RUN mkdir /var/www/html/devfiles
 COPY --from=builder /build/ /var/www/html/
 USER 0
 RUN chmod -R g+rwX /var/www/html/devfiles

--- a/check_mandatory_fields.sh
+++ b/check_mandatory_fields.sh
@@ -28,12 +28,12 @@ function check_field() {
 ## loop through meta.yaml files
 for i in $(ls -1 "${devfilesDir}/"*"/meta.yaml" | sort); do
     echo "Checking devfile '${i}'"
-    id=$(grep "displayName:" "${i}" | sed -e "s#^displayName: ##" -e 's#"##g')
+	id=$(yq ."${displayName}" "$i" | tr -d "\"") # trim quotes from the field value
     full_id=${id}:${i}
 
     unset NULL_OR_EMPTY_FIELDS
     for field in "${metaInfoFields[@]}"; do
-      value=$(grep "${field}:" "${i}" | sed -e "s#^${field}: ##" -e 's#"##g')
+	  value=$(yq ."${field}" "$i" | tr -d "\"") # trim quotes from the field value
       if ! check_field "${value}";then
         NULL_OR_EMPTY_FIELDS+="$field "
       fi

--- a/index.sh
+++ b/index.sh
@@ -34,10 +34,8 @@ function buildIndex() {
             # get value of needed field in json format
             # note that it may have differrent formats: arrays, string, etc.
             # String value contains quotes, e.g. "str"
-            value=$(grep "${field}:" "${i}" | sed -e "s#^${field}: ##")
-            # if not an array and not already wrapped in quotes, wrap in quotes
-            if [[ ${value} != "["*"]" ]] && [[ ${value} != "\""*"\"" ]]; then value="\"${value}\""; fi
-            echo "  \"$field\":$value,"
+            value="$(yq ."${field}" "$i" | sed 's/^"\(.*\)"$/\1/')"
+            echo "  \"$field\":\"$value\","
         done
 
         parentFolderPath=${i%/*}


### PR DESCRIPTION
1. #14076 don't actually need yq since we're just looking for toplevel yaml fields; can use sed with '^fieldName:' to make the container more lightweight

2. clean up Dockerfiles and switch to './index.sh devfiles' (more consistent with './check_mandatory_fields.sh devfiles')

I know some people don't like grep|sed but this is way faster than using either yq implementation, and means it'll be easier to move this container to a ubi8-minimal base.

Change-Id: I76edb47e5c407e879467b9f02ccf52a50b35efaa
Signed-off-by: nickboldt <nboldt@redhat.com>