### PR TITLE
Replace mikefarah/yq with kislyuk/yq

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-FROM mikefarah/yq as builder
-RUN apk add --no-cache bash
+FROM alpine:3.10 AS builder
+RUN apk add --no-cache py-pip jq bash && pip install yq
 
 COPY .htaccess README.md *.sh /build/
 COPY /devfiles /build/devfiles

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -6,8 +6,8 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-FROM mikefarah/yq as builder
-RUN apk add --no-cache bash
+FROM alpine:3.10 AS builder
+RUN apk add --no-cache py-pip jq bash && pip install yq
 
 COPY .htaccess README.md *.sh /build/
 COPY /devfiles /build/devfiles


### PR DESCRIPTION
### What does this PR do?
Replaces [`mikefarah/yq`](https://github.com/mikefarah/yq) with [`kislyuk/yq`](https://github.com/kislyuk/yq) and reworks `index.sh` and `check_mandatory_fields.sh` to accommodate this change.

- `index.sh` is greatly simplified and can basically be done in one step (with a workaround for self-links)
- `check_mandatory_fields.sh` no longer uses yq at all, since a simple grep command is sufficient to check if the fields are not present or empty.

Since timing is a concern in eclipse/che#14076, 
```
$ time ./check_mandatory_fields.sh devfiles
real	0m 0.05s
user	0m 0.03s
sys	0m 0.01s
$ time ./index.sh > /build/devfiles/index.json
real	0m 0.26s
user	0m 0.21s
sys	0m 0.04s
```

### What issues does this PR fix or reference?
It's some minor work from testing https://github.com/eclipse/che/issues/14076