### PR TITLE
Always tag images based on the git commit hash as part of every CI ('master', 'nightly', 'release')

### DIFF
--- a/cico_build_ci.sh
+++ b/cico_build_ci.sh
@@ -22,5 +22,4 @@ export SCRIPT_DIR
 
 load_jenkins_vars
 install_deps
-set_ci_tag
 build_and_push


### PR DESCRIPTION
### What does this PR do?
Always tag images based on the git commit hash as part of every CI ('master', 'nightly', 'release')
Want to merge this PR in the release branch and verify that rhel image is build correctly so that it would be possible to update devfile registry on production based on the release version - https://github.com/openshiftio/saas-openshiftio/blob/master/dsaas-services/che-devfile-registry.yaml#L2