### PR TITLE
Update python tooling image

### DIFF
--- a/devfiles/python-django/devfile.yaml
+++ b/devfiles/python-django/devfile.yaml
@@ -16,7 +16,7 @@ components:
   -
     type: dockerimage
     alias: python
-    image: quay.io/eclipse/che-python-3.6:nightly
+    image: centos/python-36-centos7:1
     memoryLimit: 512Mi
     endpoints:
       - name: 'django'

--- a/devfiles/python/devfile.yaml
+++ b/devfiles/python/devfile.yaml
@@ -16,7 +16,7 @@ components:
   -
     type: dockerimage
     alias: python
-    image: quay.io/eclipse/che-python-3.6:nightly
+    image: centos/python-36-centos7:1
     memoryLimit: 512Mi
     mountSources: true
 commands:


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>


### What does this PR do?
Updates python tooling image:
`quay.io/eclipse/che-python-3.6:nightly` -> `centos/python-36-centos7:1`
