### PR TITLE
Change identifier of plugin used for Camel eclipse/che#13921

### DIFF
--- a/devfiles/apache-camel-springboot/devfile.yaml
+++ b/devfiles/apache-camel-springboot/devfile.yaml
@@ -15,7 +15,7 @@ components:
     memoryLimit: 128Mi
   -
     type: chePlugin
-    id: camel-tooling/vscode-apache-camel/latest
+    id: redhat/vscode-apache-camel/latest
     memoryLimit: 200Mi
   -
     type: chePlugin


### PR DESCRIPTION
Signed-off-by: Aurélien Pupier <apupier@redhat.com>

~requires https://github.com/eclipse/che-plugin-registry/pull/186~ --> Merged