### PR TITLE
Add c/c++ base image based on...

### DIFF
--- a/arbitrary-users-patch/base_images
+++ b/arbitrary-users-patch/base_images
@@ -1,12 +1,13 @@
-che-python-3.6          centos/python-36-centos7:1
-che-python-3.7          python:3.7.4-slim
-che-php-7               eclipse/php:7.1-che7
+che-cpp-centos          registry.centos.org/centos/devtoolset-7-toolchain-centos7
+che-dotnet-2.2          mcr.microsoft.com/dotnet/core/sdk:2.2-stretch
 che-golang-1.10         golang:1.10.7-stretch
 che-golang-1.12         golang:1.12-stretch
 che-java11-gradle       gradle:5.2.1-jdk11
 che-java11-maven        maven:3.6.0-jdk-11
 che-java8-maven         maven:3.6.1-jdk-8
-che-dotnet-2.2          mcr.microsoft.com/dotnet/core/sdk:2.2-stretch
 che-nodejs10-community  node:10.16
 che-nodejs10-ubi        registry.access.redhat.com/ubi8/nodejs-10
 che-nodejs8-centos      registry.centos.org/che-stacks/centos-nodejs
+che-php-7               eclipse/php:7.1-che7
+che-python-3.6          centos/python-36-centos7:1
+che-python-3.7          python:3.7.4-slim

--- a/arbitrary-users-patch/base_images
+++ b/arbitrary-users-patch/base_images
@@ -1,4 +1,4 @@
-che-cpp-centos          registry.centos.org/centos/devtoolset-7-toolchain-centos7
+che-cpp-rhel7           registry.access.redhat.com/devtools/llvm-toolset-rhel7
 che-dotnet-2.2          mcr.microsoft.com/dotnet/core/sdk:2.2-stretch
 che-golang-1.10         golang:1.10.7-stretch
 che-golang-1.12         golang:1.12-stretch


### PR DESCRIPTION
Add c/c++ base image based on registry.centos.org/centos/devtoolset-7-toolchain-centos7; reorder containers in alpha sequence because yeah

Ref: eclipse/che#13698

Change-Id: I8d95000f756b948d29a6c935163097ccc44ade53
Signed-off-by: nickboldt <nboldt@redhat.com>