### PR TITLE
rh-che #1615 Increasing 'memoryLimit' to 150Mi for vscode-xml plugin in apache-camel-springboot devfile in order to workaround limit range issue on Hosted Che

### DIFF
--- a/devfiles/apache-camel-springboot/devfile.yaml
+++ b/devfiles/apache-camel-springboot/devfile.yaml
@@ -12,7 +12,7 @@ components:
   -
     type: chePlugin
     id: redhat/vscode-xml/latest
-    memoryLimit: 128Mi
+    memoryLimit: 150Mi
   -
     type: chePlugin
     id: redhat/vscode-apache-camel/latest


### PR DESCRIPTION
### What does this PR do?
Increasing 'memoryLimit' to 150Mi for vscode-xml plugin in apache-camel-springboot devfile in order to workaround limit range issue on Hosted Che

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/1615

## Try this PR on Hosted Che 

[![Contribute](https://che.openshift.io/factory/resources/factory-contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/ibuziuk/che-devfile-registry/test-limit/devfiles/apache-camel-springboot/devfile.yaml)
