### PR TITLE
Remove --squash from docker build so CentOS CI can build it.

### DIFF
--- a/arbitrary-users-patch/build_images.sh
+++ b/arbitrary-users-patch/build_images.sh
@@ -31,7 +31,7 @@ while read -r line; do
   base_image_name=$(echo "$line" | tr -s ' ' | cut -f 1 -d ' ')
   base_image=$(echo "$line" | tr -s ' ' | cut -f 2 -d ' ')
   echo "Building ${NAME_FORMAT}/${base_image_name}:${TAG} based on $base_image ..."
-  docker build -t "${NAME_FORMAT}/${base_image_name}:${TAG}" --no-cache --squash --build-arg FROM_IMAGE="$base_image" "${SCRIPT_DIR}"/
+  docker build -t "${NAME_FORMAT}/${base_image_name}:${TAG}" --no-cache --build-arg FROM_IMAGE="$base_image" "${SCRIPT_DIR}"/
   if ${PUSH_IMAGES}; then
     echo "Pushing ${NAME_FORMAT}/${base_image_name}:${TAG}" to remote registry
     docker push "${NAME_FORMAT}/${base_image_name}:${TAG}"


### PR DESCRIPTION
### What does this PR do?
Remove the `--squash` parameter from the CI build, as it fails on CentOS CI:
```
Building quay.io/eclipse/che-python-3.6:nightly based on centos/python-36-centos7:1 ...
"--squash" is only supported on a Docker daemon with experimental features enabled
Connection to 172.19.2.52 closed.
```

### What issues does this PR fix or reference?
Nightly build failing: https://ci.centos.org/job/devtools-che-devfile-registry-nightly/539/console