### PR TITLE
Fixing the release job. 'arbitrary-users-patch' images should be build & pushed only as part of the 'centos' target execution

### DIFF
--- a/cico_functions.sh
+++ b/cico_functions.sh
@@ -125,10 +125,13 @@ function build_and_push_release() {
 }
 
 # Build images patched to work on OpenShift (work with arbitrary user IDs) and push
-# them to registry
+# them to registry. NOTE: 'arbitrary-users-patch' images will be pushed only to the public 
+# 'https://quay.io/organization/eclipse' organization
 function build_patched_base_images() {
-  local TAG=${TAG:-${GIT_COMMIT_TAG}}
-  echo "CICO: building arbitrary-user-id patched base images with tag '${TAG}'"
-  "${SCRIPT_DIR}"/arbitrary-users-patch/build_images.sh --push
-  echo "CICO: pushed '${TAG}' version of the arbitrary-user patched base images"
+  if [ "$TARGET" == "centos" ]; then
+    local TAG=${TAG:-${GIT_COMMIT_TAG}}
+    echo "CICO: building arbitrary-user-id patched base images with tag '${TAG}'"
+    "${SCRIPT_DIR}"/arbitrary-users-patch/build_images.sh --push
+    echo "CICO: pushed '${TAG}' version of the arbitrary-user patched base images"
+  fi
 }


### PR DESCRIPTION
### What does this PR do?
Fixing the release job - https://ci.centos.org/job/devtools-che-devfile-registry-release/13/

 'arbitrary-users-patch' images should be built & pushed only as part of the 'centos' target execution.
Currently, the build is failing when pushing 'arbitrary-users-patch' to `quay.io/openshiftio/` which is smth that the release job should not do.  'arbitrary-users-patch' should be pushed only to the https://quay.io/organization/eclipse



### What issues does this PR fix or reference?
Fixing the release job - https://ci.centos.org/job/devtools-che-devfile-registry-release/13/
