### PR TITLE
Don't update registry and org in RHEL release builds

### DIFF
--- a/cico_functions.sh
+++ b/cico_functions.sh
@@ -116,8 +116,6 @@ function build_and_push() {
 function build_and_push_release() {
   echo "CICO: building release '${TAG}' version of devfile registry"
   docker build -t ${IMAGE} -f ${DOCKERFILE_PATH} . \
-    --build-arg PATCHED_IMAGES_REG=${REGISTRY} \
-    --build-arg PATCHED_IMAGES_ORG=${ORGANIZATION} \
     --build-arg PATCHED_IMAGES_TAG=${TAG}
   echo "CICO: release '${TAG}' version of devfile registry built"
   tag_push "${REGISTRY}/${ORGANIZATION}/${IMAGE}:${TAG}"


### PR DESCRIPTION
### What does this PR do?
Fixes an issue in the CI: since https://github.com/eclipse/che-devfile-registry/pull/105 disables building patched base images for RHEL-target release builds, we need to also not update the devfiles to point at the RHEL registry/organization. Otherwise, devfiles in the RHEL version of the repo will point at the `quay.io/openshiftio/<images>/<tag>` images that are no longer built.

### What issues does this PR fix or reference?
Release CI