### PR TITLE
Use java11 language tool for stacks with java11.

### DIFF
--- a/devfiles/java-gradle/devfile.yaml
+++ b/devfiles/java-gradle/devfile.yaml
@@ -11,7 +11,7 @@ projects:
 components:
   -
     type: chePlugin
-    id: redhat/java/latest
+    id: redhat/java11/latest
   -
     type: dockerimage
     alias: gradle

--- a/devfiles/java-maven/devfile.yaml
+++ b/devfiles/java-maven/devfile.yaml
@@ -11,7 +11,7 @@ projects:
 components:
   -
     type: chePlugin
-    id: redhat/java/latest
+    id: redhat/java11/latest
   -
     type: dockerimage
     alias: maven


### PR DESCRIPTION
### What does this PR do?
We have two stacks with java11 images, but development tools used with [java8 version](https://github.com/eclipse/che-plugin-registry/blob/master/v3/plugins/redhat/java/latest/meta.yaml#L16). This pr fix it.


### What issues does this PR fix or reference?
none

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>