### PR TITLE
Added dockerfile with precashed mvn articats for usage in tests.

### DIFF
--- a/arbitrary-users-patch/build_images.sh
+++ b/arbitrary-users-patch/build_images.sh
@@ -37,3 +37,10 @@ while read -r line; do
     docker push "${NAME_FORMAT}/${base_image_name}:${TAG}"
   fi
 done < "${SCRIPT_DIR}"/base_images
+
+# Build image for happy-path tests with precashed mvn dependencies
+docker build -t "${NAME_FORMAT}/happy-path:${TAG}" --no-cache --build-arg TAG=${TAG} "${SCRIPT_DIR}"/happy-path
+if ${PUSH_IMAGES}; then
+    echo "Pushing ${NAME_FORMAT}/happy-path:${TAG}" to remote registry
+    docker push "${NAME_FORMAT}/happy-path:${TAG}"
+fi

--- a/arbitrary-users-patch/happy-path/Dockerfile
+++ b/arbitrary-users-patch/happy-path/Dockerfile
@@ -1,0 +1,14 @@
+ARG TAG
+FROM quay.io/eclipse/che-java11-maven:${TAG}
+
+USER root
+
+RUN cd / && \
+    git clone https://github.com/spring-projects/spring-petclinic && \
+    cd /spring-petclinic && \
+    mvn clean package && \
+    mkdir -p /.m2 && \
+    cp -r /root/.m2/repository/* /.m2 && \
+    rm -rf spring-petclinic/ /root/.m2/repository/* 
+
+USER 10001

--- a/arbitrary-users-patch/happy-path/Dockerfile
+++ b/arbitrary-users-patch/happy-path/Dockerfile
@@ -7,8 +7,9 @@ RUN cd / && \
     git clone https://github.com/spring-projects/spring-petclinic && \
     cd /spring-petclinic && \
     mvn clean package && \
-    mkdir -p /.m2 && \
-    cp -r /root/.m2/repository/* /.m2 && \
-    rm -rf spring-petclinic/ /root/.m2/repository/* 
+    mkdir -p /home/user/.m2/repository && \
+    cp -r /root/.m2/repository/* /home/user/.m2/repository && \
+    rm -rf spring-petclinic/ /root/.m2/repository/* && \
+    chmod -R g=u /home/user
 
 USER 10001

--- a/arbitrary-users-patch/happy-path/build_happy_path_image.sh
+++ b/arbitrary-users-patch/happy-path/build_happy_path_image.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2018 Red Hat, Inc.
+# Copyright (c) 2012-2019 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -27,13 +27,9 @@ if [ "$1" == "--push" ]; then
   PUSH_IMAGES=true
 fi
 
-while read -r line; do
-  base_image_name=$(echo "$line" | tr -s ' ' | cut -f 1 -d ' ')
-  base_image=$(echo "$line" | tr -s ' ' | cut -f 2 -d ' ')
-  echo "Building ${NAME_FORMAT}/${base_image_name}:${TAG} based on $base_image ..."
-  docker build -t "${NAME_FORMAT}/${base_image_name}:${TAG}" --no-cache --build-arg FROM_IMAGE="$base_image" "${SCRIPT_DIR}"/
-  if ${PUSH_IMAGES}; then
-    echo "Pushing ${NAME_FORMAT}/${base_image_name}:${TAG}" to remote registry
-    docker push "${NAME_FORMAT}/${base_image_name}:${TAG}"
-  fi
-done < "${SCRIPT_DIR}"/base_images
+# Build image for happy-path tests with precashed mvn dependencies
+docker build -t "${NAME_FORMAT}/happy-path:${TAG}" --no-cache --build-arg TAG=${TAG} "${SCRIPT_DIR}"/
+if ${PUSH_IMAGES}; then
+    echo "Pushing ${NAME_FORMAT}/happy-path:${TAG}" to remote registry
+    docker push "${NAME_FORMAT}/happy-path:${TAG}"
+fi

--- a/cico_build_nightly.sh
+++ b/cico_build_nightly.sh
@@ -26,4 +26,5 @@ set_nightly_tag
 setup_environment
 
 build_patched_base_images
+build_happy_path_image
 build_and_push

--- a/cico_build_release.sh
+++ b/cico_build_release.sh
@@ -26,4 +26,5 @@ set_release_tag
 setup_environment
 
 build_patched_base_images
+build_happy_path_image
 build_and_push_release

--- a/cico_functions.sh
+++ b/cico_functions.sh
@@ -133,3 +133,12 @@ function build_patched_base_images() {
     echo "CICO: pushed '${TAG}' version of the arbitrary-user patched base images"
   fi
 }
+
+function build_happy_path_image() {
+  if [ "$TARGET" == "centos" ]; then
+    local TAG=${TAG:-${GIT_COMMIT_TAG}}
+    echo "CICO: building image for happy path testing with tag '${TAG}'"
+    "${SCRIPT_DIR}"/arbitrary-users-patch/happy-path/build_happy_path_image.sh --push
+    echo "CICO: pushed '${TAG}' version of the happy path image"
+  fi
+}


### PR DESCRIPTION
Signed-off-by: Radim Hopp <rhopp@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
This adds dockerfile for image based on che-java11-maven. This image contains pre-downloaded mvn artifacts and is used for testing (until now, we were using image based on some really old version of the base image)

### What issues does this PR fix or reference?


https://github.com/eclipse/che/issues/14737