### PR TITLE
Add debug config for php-web-simple.

### DIFF
--- a/devfiles/php-web-simple/devfile.yaml
+++ b/devfiles/php-web-simple/devfile.yaml
@@ -61,3 +61,23 @@ commands:
         else
           echo "DocumentRoot already configured!"
         fi
+-
+  name: Debug current file
+  actions:
+  - type: vscode-launch
+    referenceContent: |
+      {
+        "version": "0.2.0",
+        "configurations": [
+          {
+            "name": "Launch currently open script",
+            "type": "php",
+            "request": "launch",
+            "program": "${file}",
+            "stopOnEntry": true,
+            "cwd": "${fileDirname}",
+            "port": 9000,
+            "runtimeExecutable": "php"
+          }
+        ]
+      }


### PR DESCRIPTION
### What does this PR do?
Add debug config  "Launch currently open script" for php-web-simple.

How to test it:
1. Create and start workspace from devfile.
2. Open file index.php from web-simple-php project
3. Set breakpoint in 3 line.
4. Open debug panel. Should be selected configuration  "Launch currently open script"
5. Click run button.

### What issues does this PR fix or reference?
none, done in the frame of the testing sidecar images.

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>
