### PR TITLE
Updating image name based on the rhel image renaming

### DIFF
--- a/cico_functions.sh
+++ b/cico_functions.sh
@@ -77,7 +77,7 @@ function setup_environment() {
   export GIT_COMMIT_TAG
 
   if [ "$TARGET" == "rhel" ]; then
-    export DOCKERFILE_PATH="./build/dockerfiles/Dockerfile.rhel"
+    export DOCKERFILE_PATH="./build/dockerfiles/rhel.Dockerfile"
     export ORGANIZATION="openshiftio"
     export IMAGE="rhel-che-devfile-registry"
   else


### PR DESCRIPTION
### What does this PR do?
Updating image name based on the rhel image renaming in order to fix the release CI - https://ci.centos.org/job/devtools-che-devfile-registry-release/17/console
Dockerfile Renaming was introduced in https://github.com/eclipse/che-devfile-registry/pull/115

### What issues does this PR fix or reference?
N/A