### PR TITLE
che #14896 PR for triggering CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,4 @@ The following [CentOS CI jobs](https://ci.centos.org/) are associated with the r
 - [`release-preview`](https://ci.centos.org/job/devtools-che-devfile-registry-release-preview/) - builds CentOS and corresponding RHEL images from the [`release-preview`](https://github.com/eclipse/che-devfile-registry/tree/release-preview) branch and automatically updates ["Hosted Che"](https://www.eclipse.org/che/docs/che-7/hosted-che/) staging devfile registry deployment based on the new version of images - https://che-devfile-registry.prod-preview.openshift.io/. CentOS images are public and pushed to [quay.io](https://quay.io/organization/eclipse). RHEL images are also pushed to quay.io, but to the private repositories.
 
 ### License
-Che is open sourced under the Eclipse Public License 2.0.
+Che is open sourced under the Eclipse Public License 2.0


### PR DESCRIPTION
# What does this PR do?
 PR for triggering CI - https://ci.centos.org/job/devtools-che-devfile-registry-release/
Keep failing with `Get https://registry.centos.org/v2/: net/http: request canceled (Client.Timeout exceeded while awaiting headers)`


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14896