### PR TITLE
Deprecate che-golang-1.10 in favor of che-golang-1.12

### DIFF
--- a/arbitrary-users-patch/base_images
+++ b/arbitrary-users-patch/base_images
@@ -1,6 +1,5 @@
 che-cpp-rhel7           registry.access.redhat.com/devtools/llvm-toolset-rhel7
 che-dotnet-2.2          mcr.microsoft.com/dotnet/core/sdk:2.2-stretch
-che-golang-1.10         golang:1.10.7-stretch
 che-golang-1.12         golang:1.12-stretch
 che-java11-gradle       gradle:5.2.1-jdk11
 che-java11-maven        maven:3.6.0-jdk-11

--- a/devfiles/go/devfile.yaml
+++ b/devfiles/go/devfile.yaml
@@ -18,7 +18,7 @@ components:
 -
   type: dockerimage
   # this version is used in the plugin
-  image: quay.io/eclipse/che-golang-1.10:nightly
+  image: quay.io/eclipse/che-golang-1.12:nightly
   alias: go-cli
   env:
     - name: GOPATH

--- a/devfiles/go/meta.yaml
+++ b/devfiles/go/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: Go
-description: Stack with Go 1.10.7
+description: Stack with Go 1.12.10
 tags: ["Debian", "Go"]
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 globalMemoryLimit: 1686Mi


### PR DESCRIPTION
### What does this PR do?
Remove `che-golang-1.10` from list of arbitrary UID patched images in favor of `che-golang-1.12`. This PR will stop nightly/release builds of that image and make new workspaces created using to go devfile use 1.12. We still need to decide what to do with the existing `che-golang-1.10` images on quay.io, since old workspaces may depend on it.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14265