### PR TITLE
Improve how offline project zips are created

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 FROM alpine:3.10 AS builder
-RUN apk add --no-cache py-pip jq bash && pip install yq
+RUN apk add --no-cache py-pip jq bash git && pip install yq
 
 # Registry, organization, and tag to use for base images in dockerfiles. Devfiles
 # will be rewritten during build to use these values for base images.

--- a/build/dockerfiles/rhel.install.sh
+++ b/build/dockerfiles/rhel.install.sh
@@ -8,7 +8,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-microdnf install -y findutils bash wget yum gzip tar jq python3-six python3-pip && microdnf -y clean all && \
+microdnf install -y findutils bash wget yum gzip git tar jq python3-six python3-pip && microdnf -y clean all && \
 # install yq (depends on jq and pyyaml - if jq and pyyaml not already installed, this will try to compile it)
 if [[ -f /tmp/root-local.tgz ]] || [[ ${BOOTSTRAP} == "true" ]]; then \
     mkdir -p /root/.local; tar xf /tmp/root-local.tgz -C /root/.local/; rm -fr /tmp/root-local.tgz;  \


### PR DESCRIPTION
### What does this PR do?
Changes offline functionality so that cached project zips are instead `git clone`d and `git archive`d.

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/14800