### PR TITLE
Add list of external images to server when offline registry is built

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,21 +1,6 @@
-#!/bin/sh
-#
-# Copyright (c) 2012-2018 Red Hat, Inc.
-# This program and the accompanying materials are made
-# available under the terms of the Eclipse Public License 2.0
-# which is available at https://www.eclipse.org/legal/epl-2.0/
-#
-# SPDX-License-Identifier: EPL-2.0
-#
-# Build Che devfile registry image. Note that this script will read the version
-# in ./VERSION; if it is *-SNAPSHOT, devfiles in the registry will use nightly-tagged
-# images with the arbitrary user IDs patch. If ./VERSION contains otherwise,
-# the devfiles in the registry will instead use the value in ./VERSION.
-#
-
 #!/bin/bash
 #
-# Copyright (c) 2012-2018 Red Hat, Inc.
+# Copyright (c) 2019 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -86,26 +71,7 @@ function parse_arguments() {
 
 parse_arguments "$@"
 
-IMAGE="${REGISTRY}/${ORGANIZATION}/che-plugin-registry:${TAG}"
-echo -n "Building image '$IMAGE' "
-if [ "$OFFLINE" = true ]; then
-    echo "in offline mode"
-    docker build \
-        -t "$IMAGE" \
-        -f ./build/dockerfiles/Dockerfile \
-        --build-arg LATEST_ONLY="${LATEST_ONLY}" \
-        --target offline-registry .
-else
-    echo ""
-    docker build \
-        -t "$IMAGE" \
-        -f ./build/dockerfiles/Dockerfile \
-        --build-arg LATEST_ONLY="${LATEST_ONLY}" \
-        --target registry .
-fi
-
 IMAGE="${REGISTRY}/${ORGANIZATION}/che-devfile-registry:${TAG}"
-
 VERSION=$(head -n 1 VERSION)
 case $VERSION in
   *SNAPSHOT)

--- a/build.sh
+++ b/build.sh
@@ -13,16 +13,107 @@
 # the devfiles in the registry will instead use the value in ./VERSION.
 #
 
+#!/bin/bash
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+set -e
+
+REGISTRY="quay.io"
+ORGANIZATION="eclipse"
+TAG="nightly"
+TARGET="registry"
+DOCKERFILE="./build/dockerfiles/Dockerfile"
+
+USAGE="
+Usage: ./build.sh [OPTIONS]
+Options:
+    --help
+        Print this message.
+    --tag, -t [TAG]
+        Docker image tag to be used for image; default: 'nightly'
+    --registry, -r [REGISTRY]
+        Docker registry to be used for image; default 'quay.io'
+    --organization, -o [ORGANIZATION]
+        Docker image organization to be used for image; default: 'eclipse'
+    --offline
+        Build offline version of registry, with all sample projects
+        cached in the registry; disabled by default.
+    --rhel
+        Build registry using UBI images instead of default
+"
+
+function print_usage() {
+    echo -e "$USAGE"
+}
+
+function parse_arguments() {
+    while [[ $# -gt 0 ]]; do
+        key="$1"
+        case $key in
+            -t|--tag)
+            TAG="$2"
+            shift; shift;
+            ;;
+            -r|--registry)
+            REGISTRY="$2"
+            shift; shift;
+            ;;
+            -o|--organization)
+            ORGANIZATION="$2"
+            shift; shift;
+            ;;
+            --offline)
+            TARGET="offline-registry"
+            shift
+            ;;
+            --rhel)
+            DOCKERFILE="./build/dockerfiles/rhel.Dockerfile"
+            shift
+            ;;
+            *)
+            print_usage
+            exit 0
+        esac
+    done
+}
+
+parse_arguments "$@"
+
+IMAGE="${REGISTRY}/${ORGANIZATION}/che-plugin-registry:${TAG}"
+echo -n "Building image '$IMAGE' "
+if [ "$OFFLINE" = true ]; then
+    echo "in offline mode"
+    docker build \
+        -t "$IMAGE" \
+        -f ./build/dockerfiles/Dockerfile \
+        --build-arg LATEST_ONLY="${LATEST_ONLY}" \
+        --target offline-registry .
+else
+    echo ""
+    docker build \
+        -t "$IMAGE" \
+        -f ./build/dockerfiles/Dockerfile \
+        --build-arg LATEST_ONLY="${LATEST_ONLY}" \
+        --target registry .
+fi
+
+IMAGE="${REGISTRY}/${ORGANIZATION}/che-devfile-registry:${TAG}"
+
 VERSION=$(head -n 1 VERSION)
 case $VERSION in
   *SNAPSHOT)
     echo "Snapshot version (${VERSION}) specified in $(find . -name VERSION): building nightly plugin registry."
-    docker build -t "quay.io/eclipse/che-devfile-registry:nightly" -f ./build/dockerfiles/Dockerfile --target registry .
+    docker build -t "${IMAGE}" -f ${DOCKERFILE} --target ${TARGET} .
     ;;
   *)
     echo "Release version specified in $(find . -name VERSION): Building plugin registry for release ${VERSION}."
-    docker build -t "quay.io/eclipse/che-devfile-registry:${VERSION}" -f ./build/dockerfiles/Dockerfile . \
-        --build-arg "PATCHED_IMAGES_TAG=${VERSION}" \
-        --target registry
+    docker build -t "${IMAGE}" -f ${DOCKERFILE} --target ${TARGET} --build-arg "PATCHED_IMAGES_TAG=${VERSION}" .
     ;;
 esac

--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -37,6 +37,7 @@ CMD ["/usr/bin/run-httpd"]
 
 # Offline registry: download project zips and place them in /build/resources
 FROM builder AS offline-builder
+RUN ./list_referenced_images.sh devfiles > /build/devfiles/external_images.txt
 RUN ./cache_projects.sh devfiles resources && chmod -R g+rwX /build
 
 # Offline registry: copy updated devfile.yamls and cached projects

--- a/build/dockerfiles/rhel.Dockerfile
+++ b/build/dockerfiles/rhel.Dockerfile
@@ -97,6 +97,7 @@ CMD ["/usr/local/bin/rhel.entrypoint.sh"]
 
 # Offline devfile registry build
 FROM builder AS offline-builder
+RUN ./list_referenced_images.sh devfiles > /build/devfiles/external_images.txt
 RUN ./cache_projects.sh devfiles resources && chmod -R g+rwX /build
 
 FROM registry AS offline-registry

--- a/build/scripts/list_referenced_images.sh
+++ b/build/scripts/list_referenced_images.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# List all images referenced in meta.yaml files
+#
+
+set -e
+
+readarray -d '' devfiles < <(find "$1" -name 'devfile.yaml' -print0)
+yq -r '.components[] | if has("image") then .image else empty end' "${devfiles[@]}" | sort | uniq


### PR DESCRIPTION
### What does this PR do?
Adds building a list of externally-referenced images to the offline build to make it easier for users to know which images need to be pulled into a private registry.

Required for https://github.com/eclipse/che/issues/14866

Also rewrites the `build.sh` script to be similar to the one in the plugin registry (with options)