### PR TITLE
Update offline registry endpoint env var to not mention https

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The default docker build has multiple targets:
 - `--target registry` is used to build the default devfile registry, where projects in devfiles refer to publically hosted git repos
 - `--target offline-registry` is used to build a devfile registry which self-hosts projects as zip files.
 
-The offline registry build will, during the docker build, pull zips from all projects hosted on github and store them in the `/resources` path. This registry should be deployed with environment variable `CHE_DEVFILE_HTTP_ENDPOINT` set to the URL of the route/endpoint that exposes the devfile registry, as devfiles need to be rewritten to point to internally hosted zip files.
+The offline registry build will, during the docker build, pull zips from all projects hosted on github and store them in the `/resources` path. This registry should be deployed with environment variable `CHE_DEVFILE_REGISTRY_URL` set to the URL of the route/endpoint that exposes the devfile registry, as devfiles need to be rewritten to point to internally hosted zip files.
 
 ## OpenShift
 You can deploy Che devfile registry on Openshift with command.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The default docker build has multiple targets:
 - `--target registry` is used to build the default devfile registry, where projects in devfiles refer to publically hosted git repos
 - `--target offline-registry` is used to build a devfile registry which self-hosts projects as zip files.
 
-The offline registry build will, during the docker build, pull zips from all projects hosted on github and store them in the `/resources` path. This registry should be deployed with environment variable `CHE_DEVFILE_HTTPS_ENDPOINT` set to the URL of the route/endpoint that exposes the devfile registry, as devfiles need to be rewritten to point to internally hosted zip files.
+The offline registry build will, during the docker build, pull zips from all projects hosted on github and store them in the `/resources` path. This registry should be deployed with environment variable `CHE_DEVFILE_HTTP_ENDPOINT` set to the URL of the route/endpoint that exposes the devfile registry, as devfiles need to be rewritten to point to internally hosted zip files.
 
 ## OpenShift
 You can deploy Che devfile registry on Openshift with command.

--- a/build/dockerfiles/entrypoint.sh
+++ b/build/dockerfiles/entrypoint.sh
@@ -19,7 +19,7 @@
 # In addition, this script will perform the necessary set up for the offline
 # devfile registry, replacing placeholders in all devfiles based off environment
 # variable
-#     CHE_DEVFILE_HTTPS_ENDPOINT
+#     CHE_DEVFILE_HTTP_ENDPOINT
 # which should be set to the public endpoint for this registry.
 #
 # Will execute any arguments on completion (`exec $@`)
@@ -29,7 +29,7 @@ set -e
 REGISTRY=${CHE_DEVFILE_IMAGES_REGISTRY_URL}
 ORGANIZATION=${CHE_DEVFILE_IMAGES_REGISTRY_ORGANIZATION}
 TAG=${CHE_DEVFILE_IMAGES_REGISTRY_TAG}
-PUBLIC_URL=${CHE_DEVFILE_HTTPS_ENDPOINT}
+PUBLIC_URL=${CHE_DEVFILE_HTTP_ENDPOINT}
 
 DEFAULT_DEVFILES_DIR="/var/www/html/devfiles"
 DEVFILES_DIR="${DEVFILES_DIR:-${DEFAULT_DEVFILES_DIR}}"
@@ -71,7 +71,7 @@ if [ -n "$PUBLIC_URL" ]; then
   sed -i "s|{{ DEVFILE_REGISTRY_URL }}|${PUBLIC_URL}|" "${devfiles[@]}"
 else
   if grep -q '{{ DEVFILE_REGISTRY_URL }}' "${devfiles[@]}"; then
-    echo "WARNING: environment variable 'CHE_DEVFILE_HTTPS_ENDPOINT' not configured" \
+    echo "WARNING: environment variable 'CHE_DEVFILE_HTTP_ENDPOINT' not configured" \
          "for an offline build of this registry. This may cause issues with importing" \
          "projects in a workspace."
     # Experimental workaround -- detect service IP for che-devfile-registry

--- a/build/dockerfiles/entrypoint.sh
+++ b/build/dockerfiles/entrypoint.sh
@@ -19,7 +19,7 @@
 # In addition, this script will perform the necessary set up for the offline
 # devfile registry, replacing placeholders in all devfiles based off environment
 # variable
-#     CHE_DEVFILE_HTTP_ENDPOINT
+#     CHE_DEVFILE_REGISTRY_URL
 # which should be set to the public endpoint for this registry.
 #
 # Will execute any arguments on completion (`exec $@`)
@@ -29,7 +29,7 @@ set -e
 REGISTRY=${CHE_DEVFILE_IMAGES_REGISTRY_URL}
 ORGANIZATION=${CHE_DEVFILE_IMAGES_REGISTRY_ORGANIZATION}
 TAG=${CHE_DEVFILE_IMAGES_REGISTRY_TAG}
-PUBLIC_URL=${CHE_DEVFILE_HTTP_ENDPOINT}
+PUBLIC_URL=${CHE_DEVFILE_REGISTRY_URL}
 
 DEFAULT_DEVFILES_DIR="/var/www/html/devfiles"
 DEVFILES_DIR="${DEVFILES_DIR:-${DEFAULT_DEVFILES_DIR}}"
@@ -71,7 +71,7 @@ if [ -n "$PUBLIC_URL" ]; then
   sed -i "s|{{ DEVFILE_REGISTRY_URL }}|${PUBLIC_URL}|" "${devfiles[@]}"
 else
   if grep -q '{{ DEVFILE_REGISTRY_URL }}' "${devfiles[@]}"; then
-    echo "WARNING: environment variable 'CHE_DEVFILE_HTTP_ENDPOINT' not configured" \
+    echo "WARNING: environment variable 'CHE_DEVFILE_REGISTRY_URL' not configured" \
          "for an offline build of this registry. This may cause issues with importing" \
          "projects in a workspace."
     # Experimental workaround -- detect service IP for che-devfile-registry


### PR DESCRIPTION
### What does this PR do?
Change environment variable for offline public endpoint to `CHE_DEVFILE_HTTP_ENDPOINT` instead of HTTPS since it is confusing.
