### PR TITLE
Fix regex used for processing image references

### DIFF
--- a/build/dockerfiles/entrypoint.sh
+++ b/build/dockerfiles/entrypoint.sh
@@ -41,7 +41,7 @@ DEVFILES_DIR="${DEVFILES_DIR:-${DEFAULT_DEVFILES_DIR}}"
 #   \4 - Image name portion of image, e.g. quay.io/eclipse/(che-theia):tag
 #   \5 - Tag of image, e.g. quay.io/eclipse/che-theia:(tag)
 #   \6 - Optional quotation following image reference
-IMAGE_REGEX='([[:space:]]*"?)([._a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*):([._a-zA-Z0-9-]*)("?)'
+IMAGE_REGEX='([[:space:]]*"?)([._:a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*):([._a-zA-Z0-9-]*)("?)'
 
 # We can't use the `-d` option for readarray because
 # registry.centos.org/centos/httpd-24-centos7 ships with Bash 4.2


### PR DESCRIPTION
### What does this PR do?
Fixes the image regex we use to break an image reference into `repo/org/image:tag`. Currently it fails to match if registry hostname contains a port, since it does not match the colon.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14990