### PR TITLE
Adding cpu and memory requests / limits to the openshift template

### DIFF
--- a/deploy/openshift/che-devfile-registry.yaml
+++ b/deploy/openshift/che-devfile-registry.yaml
@@ -58,7 +58,11 @@ objects:
             periodSeconds: 10
             timeoutSeconds: 3
           resources:
+            requests:
+              cpu: 1m
+              memory: 5Mi
             limits:
+              cpu: 100m
               memory: ${MEMORY_LIMIT}
           envFrom:
           - configMapRef:


### PR DESCRIPTION
### What does this PR do?
Adding cpu and memory requests / limits to the openshift template:
Usage from production:
ram: 13Mb
cpu: 0.002 


### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/1664

NOTE: must be also backported to 7.3.x branch https://github.com/eclipse/che-devfile-registry/pull/142