### PR TITLE
Add Quarkus devfile

### DIFF
--- a/devfiles/quarkus/devfile.yaml
+++ b/devfiles/quarkus/devfile.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: 1.0.0
+metadata:
+  generateName: quarkus-
+projects:
+  -
+    name: quarkus-quickstarts
+    source:
+      type: git
+      location: "https://github.com/quarkusio/quarkus-quickstarts.git"
+      sparseCheckoutDir: /getting-started/
+components:
+  -
+    type: chePlugin
+    id: redhat/quarkus/latest
+  -
+    type: dockerimage
+    alias: maven
+    image: quay.io/eclipse/che-quarkus:nightly
+    env:
+      - name: JAVA_OPTS
+        value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
+          -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
+          -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom
+          -Duser.home=/home/user"
+      - name: MAVEN_OPTS
+        value: $(JAVA_OPTS)  
+    memoryLimit: 512Mi
+    mountSources: true
+    volumes:
+      - name: m2
+        containerPath: /home/user/.m2
+    endpoints:
+      - name: 'quarkus-getting-started'
+        port: 8080    
+commands:
+  -
+    name: maven package
+    actions:
+      -
+        type: exec
+        component: maven
+        command: "mvn package"
+        workdir: ${CHE_PROJECTS_ROOT}/quarkus-quickstarts/getting-started
+  -
+    name: maven run in development mode
+    actions:
+      -
+        type: exec
+        component: maven
+        command: "mvn compile quarkus:dev"
+        workdir: ${CHE_PROJECTS_ROOT}/quarkus-quickstarts/getting-started
+  -
+    name: Attach remote debugger
+    actions:
+    - type: vscode-launch
+      referenceContent: |
+        {
+          "version": "0.2.0",
+          "configurations": [
+            {
+              "type": "java",
+              "request": "attach",
+              "name": "Attach to Remote Quarkus App",
+              "hostName": "localhost",
+              "port": 5005
+            }
+          ]
+        }

--- a/devfiles/quarkus/devfile.yaml
+++ b/devfiles/quarkus/devfile.yaml
@@ -31,11 +31,15 @@ components:
       - name: m2
         containerPath: /home/user/.m2
     endpoints:
-      - name: 'quarkus-getting-started'
+      - name: 'quarkus-development-server'
         port: 8080    
+      - name: 'hello-greeting-endpoint'
+        port: 8080
+        attributes:
+          path: /hello/greeting/che-user
 commands:
   -
-    name: maven package
+    name: Package the application
     actions:
       -
         type: exec
@@ -43,7 +47,7 @@ commands:
         command: "mvn package"
         workdir: ${CHE_PROJECTS_ROOT}/quarkus-quickstarts/getting-started
   -
-    name: maven run in development mode
+    name: Start development server
     actions:
       -
         type: exec

--- a/devfiles/quarkus/devfile.yaml
+++ b/devfiles/quarkus/devfile.yaml
@@ -12,7 +12,7 @@ projects:
 components:
   -
     type: chePlugin
-    id: redhat/quarkus/latest
+    id: redhat/quarkus-java8/latest
   -
     type: dockerimage
     alias: maven

--- a/devfiles/quarkus/meta.yaml
+++ b/devfiles/quarkus/meta.yaml
@@ -1,0 +1,6 @@
+---
+displayName: Quarkus Tools
+description: Quarkus Tools with OpenJDK 8 and Maven 3.6.0
+tags: ["Java", "Quarkus", "OpenJDK", "Maven", "Debian"]
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+globalMemoryLimit: 2674Mi


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Adds a devfile to support Qurakus tools.
#### This devfile includes

- 2 components:
  - dev component is based on `quay.io/quarkus/centos-quarkus-maven:19.2.1` which contains Java 8,  Maven 3.6.0 and GraalVM 19.2.1
  - qurkus plugin (for more information take a look at https://github.com/eclipse/che-plugin-registry/pull/291)  

- 2 commands:
  - mvn package
  - mvn compile quarkus:dev

- The application could be debugged by predefined debug configuration in case `mvn compile quarkus:dev` was executed before.

This devfile doesn't include commands to run native compilation because it requires more than 3GB RAM for workspace in total and it's not available on Hosted Che.   

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14506