### PR TITLE
Prepare an image for Quarkus dev environment

### DIFF
--- a/arbitrary-users-patch/base_images
+++ b/arbitrary-users-patch/base_images
@@ -10,3 +10,4 @@ che-nodejs8-centos      registry.centos.org/che-stacks/centos-nodejs
 che-php-7               eclipse/php:7.1-che7
 che-python-3.6          centos/python-36-centos7:1
 che-python-3.7          python:3.7.4-slim
+che-quarkus             quay.io/quarkus/centos-quarkus-maven:19.2.1


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Patches quay.io/quarkus/centos-quarkus-maven:19.2.1 to use it Quarkus devfile as a dev environment.

**This image contains:**
OpenJDK 1.8.0_232
GraalVM 19.2.1
Apache Maven 3.6.1 


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14506