### PR TITLE
feat(core): Provide an Apache Camel K stack eclipse/che#14831

### DIFF
--- a/devfiles/apache-camel-k/devfile.yaml
+++ b/devfiles/apache-camel-k/devfile.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: 1.0.0
+metadata:
+  generateName: apache-camel-k-
+projects:
+  -
+    name: camel-k-examples
+    source:
+      type: git
+      location: "https://github.com/apache/camel-k"
+      sparseCheckoutDir: "examples"
+components:
+  -
+    type: chePlugin
+    id: redhat/vscode-xml/latest
+  -
+    type: chePlugin
+    id: redhat/vscode-apache-camel/latest
+  -
+    alias: vscode-camelk
+    type: chePlugin
+    id: redhat/vscode-camelk/latest

--- a/devfiles/apache-camel-k/meta.yaml
+++ b/devfiles/apache-camel-k/meta.yaml
@@ -1,0 +1,6 @@
+---
+displayName: Apache Camel K
+description: Stack with tooling ready to develop Integration projects with Apache Camel K
+tags: ["Apache Camel K", "Red Hat Fuse", "Integration"]
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+globalMemoryLimit: 2850Mi


### PR DESCRIPTION
this is a first iteration with minimal set of plugins (Camel K,
Kubernetes, xml) and a pointer to Camel K official examples

To test:
can create workspace with https://<your-che-host>/f?url=https://raw.githubusercontent.com/apupier/che-devfile-registry/14831-ApacheCamelKStack/devfiles/apache-camel-k/devfile.yaml

- need to log to a Kubernetes cluster on which Camek K runtime is installed or can be installed, some potential ways:
-- chectl workspace:inject -k (if you're locally logged to on and Che is installed locally)
-- open terminal in the workspace, create ~/.kube/config with content retrieved from `kubectl config view --raw --flatten --minify` command launched in a place where you are logged in
- in case Camel K is not yet installed AND you have enough rights
-- switch to che namespace (can be done through Kubernetes perspective in  `Clusters` --> <yourCluster> -> `Namespaces` --> right-click on `che` --> `Use Namespaces`)
--  open terminal from the vscode-camelkXXX container in the workspace and call `kamel install`

Then you can right-click on one of the Camel K files (for instance simple.groovy) and choose "Start Apache Camel K Integration" and then choose "Basic mode" type, after few seconds/minutes, the panel `Apache Camel K integrations` of Explorer perspective should have another entry called simple with a green dot 
Be patient for the first runs, it takes time for first deployment and to have the correct feedback in Apache Camel K integrations (can be up to few minutes)

Nota:
- Having a Camel K instance is a requirement, it cannot come with the Che devfile
- it is currently required to set the kubeconfig manually on each workspace start, this is not a specificity of this stack. see https://github.com/eclipse/che/issues/14877
- ~~currently the readme which is opening is nto the right one, it will be fixed when either this PR https://github.com/apache/camel-k/pull/1106 or this issue https://github.com/eclipse/che/issues/15080 has been merged/fixed~~

### What does this PR do?


### What issues does this PR fix or reference?

eclipse/che#14831