### PR TITLE
Add preLaunchTask into .Net debug configuration

### DIFF
--- a/devfiles/dotnet/devfile.yaml
+++ b/devfiles/dotnet/devfile.yaml
@@ -68,6 +68,7 @@ commands:
                   "args": [],
                   "name": ".NET Core Launch (console)",
                   "stopAtEntry": false,
+                  "preLaunchTask": "build",
                   "console": "internalConsole"
               }
           ]


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Adds `preLaunchTask` into .Net debug configuration

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15025