### PR TITLE
Che4z-1.1.0

### DIFF
--- a/devfiles/che4z/devfile.yaml
+++ b/devfiles/che4z/devfile.yaml
@@ -17,10 +17,7 @@ components:
     id: broadcommfd/debugger-for-mainframe/latest
   - 
     type: chePlugin
-    id: broadcommfd/hlasm-language-support/latest    
-  - 
-    id: eclipse/che-theia/latest
-    type: cheEditor
+    id: broadcommfd/hlasm-language-support/latest
   - 
     alias: zowe-cli
     type: kubernetes

--- a/devfiles/che4z/devfile.yaml
+++ b/devfiles/che4z/devfile.yaml
@@ -13,10 +13,13 @@ components:
     type: chePlugin
     id: broadcommfd/explorer-for-endevor/latest
   - 
-    id: eclipse/che-machine-exec-plugin/7.3.0
     type: chePlugin
+    id: broadcommfd/debugger-for-mainframe/latest
   - 
-    id: eclipse/che-theia/7.3.0
+    type: chePlugin
+    id: broadcommfd/hlasm-language-support/latest    
+  - 
+    id: eclipse/che-theia/latest
     type: cheEditor
   - 
     alias: zowe-cli

--- a/devfiles/che4z/meta.yaml
+++ b/devfiles/che4z/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: Mainframe Basic Stack
 description: Mainframe Basic Stack
-tags: ["Che4z", "Zowe", "mainframe", "Endevor", "explorer", "dataset", "COBOL", "JCL", "zOS", "USS"]
+tags: ["Che4z", "Zowe", "mainframe", "Endevor", "explorer", "dataset", "COBOL", "JCL", "zOS", "USS", "HLASM", "InterTest", "debug"]
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 globalMemoryLimit: 2280Mi


### PR DESCRIPTION
Added debugger-for-mainframe and hlasm-language-support

Signed-off-by: Filip Kroupa <filip.kroupa@broadcom.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?

Update Che4z devfile to include newly added plugins [eclipse/che-plugin-registry#322](https://github.com/eclipse/che-plugin-registry/pull/322)


Targetting [Milestone 7.6.0](https://github.com/eclipse/che/milestone/107)

### What issues does this PR fix or reference?

N/A