### PR TITLE
Set CHE_DEVFILE_REGISTRY_URL environment variable.

### DIFF
--- a/deploy/kubernetes/che-devfile-registry/templates/configmap.yaml
+++ b/deploy/kubernetes/che-devfile-registry/templates/configmap.yaml
@@ -15,3 +15,4 @@ data:
   CHE_DEVFILE_IMAGES_REGISTRY_URL: {{ .Values.cheDevfileImagesOverride.url }}
   CHE_DEVFILE_IMAGES_REGISTRY_ORGANIZATION: {{ .Values.cheDevfileImagesOverride.organization }}
   CHE_DEVFILE_IMAGES_REGISTRY_TAG: {{ .Values.cheDevfileImagesOverride.tag }}
+  CHE_DEVFILE_REGISTRY_URL: http{{- if .Values.cheDevfileRegistryIngressSecretName -}}s{{- end -}}{{- printf "://che-devfile-registry-%s.%s" .Release.Namespace .Values.global.ingressDomain }}


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>

### What does this PR do?

Sets CHE_DEVFILE_REGISTRY_URL environment variable.
It will be replaced base URL to `http://{Pod's local IP}:8080/` if this environement variable wasn't set in `offline-registry` mode. 

I'm not an OpenShift specialist. So I just fixed for Kubernetes by this patch.
But I guess a similar patch will be required on OpenShift also.

### What issues does this PR fix or reference?

None.