### PR TITLE
Set up CI for repo using github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  pull_request:
+    branches: 
+      - master
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Shellcheck
+        run: |
+          find . -type f -name '*.sh' | wc -l
+          find . -type f -name '*.sh' | xargs shellcheck --external-sources
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Cache docker layers
+      uses: actions/cache@v1
+      with:
+        path: ./caches
+        key: v1-${{ github.head_ref }}
+        
+    - name: Load docker layer cache
+      run: |
+        set +o pipefail
+        docker load -i ./caches/app.tar | true
+    
+    - name: Build devfile registry
+      run: |
+        docker build \
+          --cache-from=app \
+          -t app \
+          -f ./build/dockerfiles/Dockerfile \
+          --target registry .
+           
+    - name: Cache docker layers
+      run: |
+        mkdir -p ./caches
+        docker save -o ./caches/app.tar app
+    
+    - name: Build offline devfile registry
+      run: |
+        docker build \
+          --cache-from=app \
+          -t app \
+          -f ./build/dockerfiles/Dockerfile \
+          --target offline-registry .
+   
+


### PR DESCRIPTION
### What does this PR do?
Add CI for pull requests that
1. Runs shellcheck on all scripts
2. Builds the registry
3. Builds an offline registry

To test, I added it to [my fork](https://github.com/amisevsk/che-devfile-registry/pull/1/checks)

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/14867