### PR TITLE
[airgap] Fix permissions on /var/www/html/devfiles

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -28,7 +28,7 @@ RUN ./list_referenced_images.sh devfiles > /build/devfiles/external_images.txt
 RUN chmod -R g+rwX /build/devfiles
 
 FROM registry.centos.org/centos/httpd-24-centos7 AS registry
-RUN mkdir /var/www/html/devfiles
+RUN mkdir -m 777 /var/www/html/devfiles
 COPY .htaccess README.md /var/www/html/
 COPY --from=builder /build/devfiles /var/www/html/devfiles
 COPY ./build/dockerfiles/entrypoint.sh /usr/bin/

--- a/build/dockerfiles/rhel.Dockerfile
+++ b/build/dockerfiles/rhel.Dockerfile
@@ -88,7 +88,7 @@ STOPSIGNAL SIGWINCH
 
 WORKDIR /var/www/html
 
-RUN mkdir /var/www/html/devfiles
+RUN mkdir -m 777 /var/www/html/devfiles
 COPY .htaccess README.md /var/www/html/
 COPY --from=builder /build/devfiles /var/www/html/devfiles
 COPY ./build/dockerfiles/rhel.entrypoint.sh ./build/dockerfiles/entrypoint.sh /usr/local/bin/


### PR DESCRIPTION
### What does this PR do?
In docker, copying from a previous stage does not preserve permissions when it creates a directory; this results in the /var/www/html/devfiles directory not having group write permissions, which in turn causes the airgap options to fail.

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/15547