### PR TITLE
gometalint is deprecated, use golangci-lint...

### DIFF
--- a/devfiles/go/devfile.yaml
+++ b/devfiles/go/devfile.yaml
@@ -15,6 +15,9 @@ components:
   id: ms-vscode/go/latest
   alias: go-plugin
   memoryLimit: 512Mi
+  preferences:
+    go.lintTool: 'golangci-lint'
+    go.lintFlags: '--fast'
 -
   type: dockerimage
   # this version is used in the plugin


### PR DESCRIPTION
gometalint is deprecated, use golangci-lint instead

Change-Id: I3e519c600ccdd2f231b168e281e1e4eed21293c7
Signed-off-by: Esteban Mañaricua <emanaricua@gmail.com>