### PR TITLE
Add docker image volume to mongo container in java-mongo devfile

### DIFF
--- a/devfiles/java-mongo/devfile.yaml
+++ b/devfiles/java-mongo/devfile.yaml
@@ -63,6 +63,9 @@ components:
       discoverable: 'true'
       public: 'false'
     port: 27017
+  volumes:
+  - name: mongodb_data
+    containerPath: /var/lib/mongodb/data
 commands:
 -
   name: maven build backend


### PR DESCRIPTION
### What does this PR do?
The mongodb container in the java-mongo devfile mounts a volume, which causes it to be unrunnable on Hosted Che. 

This PR adds a volume for the mongodb container to make it runnable, but there's no way to force a volume such as this to be emptyDir, so we do introduce all the risks of storing more data in a PV (slow writes, potentially, etc.).

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/15850