### PR TITLE
chore(github): Code Owners of devfile registry is members of Language…

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global Owners
-* @tsmaeder @JPinkney @svor @sunix @benoitf
+* @tsmaeder @JPinkney @svor @sunix @benoitf @amisevsk @nickboldt

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global Owners
-* @vparfonov @l0rd @rhopp @skabashnyuk @amisevsk @nickboldt @ibuziuk
+* @tsmaeder @JPinkney @svor @sunix @benoitf


### PR DESCRIPTION
### What does this PR do?

Based on last che SOS and based on repositories scope:

https://docs.google.com/document/d/1h6t4novpcRHjxe8DrEhTamDmit9VviOqcMQNtahM9uE/edit#heading=h.nh4qax6oermn

owners of che-devfile-registry is Thomas with languages team

Change-Id: I3e67500e8306a6b6ff848cdf892a86bd35a057fd
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
