### PR TITLE
chore(github): Update owners to match the team responsible of repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global Owners
-* @tsmaeder @JPinkney @svor @sunix @benoitf @amisevsk @nickboldt
+* @tsmaeder @JPinkney @svor @sunix @benoitf


### PR DESCRIPTION
### What does this PR do?
To start, owners are the one which are responsible of the repository.
Other committers will be able to merge as well when repository settings will be updated (as discussed in the Eclipse Che calls)

### What issues does this PR fix or reference?
N/A

Change-Id: Ife8c69d1c6b9331986e808922f83663f3abcdd59
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
