### PR TITLE
Do not override entrypoint that initializes /etc/passwd file

### DIFF
--- a/devfiles/cpp/devfile.yaml
+++ b/devfiles/cpp/devfile.yaml
@@ -20,8 +20,6 @@ components:
   type: dockerimage
   alias: cpp-dev
   image: quay.io/eclipse/che-cpp-rhel7:nightly
-  command: ['sleep']
-  args: ['infinity']
   memoryLimit: 512Mi
   mountSources: true
 commands:

--- a/devfiles/dotnet-asp.net/devfile.yaml
+++ b/devfiles/dotnet-asp.net/devfile.yaml
@@ -21,8 +21,6 @@ components:
     type: dockerimage
     alias: dotnet
     image: quay.io/eclipse/che-dotnet-2.2:nightly
-    command: ['sleep']
-    args: ['infinity']
     env:
       - name: HOME
         value: /home/user


### PR DESCRIPTION
### What does this PR do?
This PR fixes terminal launching that was caused by overridden entrypoint that initializes /etc/passwd file.
https://github.com/eclipse/che-dockerfiles/blob/master/recipes/stack-base/ubuntu/Dockerfile#L79

Actually, there is some bug in che-machine-terminal and missing /etc/passwd should not prevent the terminal from launching but it's another issue I'll try to handle in a scope of https://github.com/eclipse/che-machine-exec/pull/82

### What issues does this PR fix or reference?
It fixes https://github.com/eclipse/che/issues/15969