### PR TITLE
Increase memory for java-mysql petclinic devfile

### DIFF
--- a/devfiles/java-mysql/devfile.yaml
+++ b/devfiles/java-mysql/devfile.yaml
@@ -28,7 +28,7 @@ components:
           -Duser.home=/home/user"
       - name: MAVEN_OPTS
         value: $(JAVA_OPTS)
-    memoryLimit: 700Mi
+    memoryLimit: 1000Mi
     endpoints:
       - name: '8080/tcp'
         port: 8080

--- a/devfiles/java-mysql/meta.yaml
+++ b/devfiles/java-mysql/meta.yaml
@@ -3,4 +3,4 @@ displayName: Java with Spring Boot and MySQL
 description: Java stack with OpenJDK 8, MySQL and Spring Boot Petclinic demo application
 tags: ["Java", "OpenJDK", "Maven", "Spring Boot", "MySQL"]
 icon: /images/springboot.svg
-globalMemoryLimit: 3072Mi
+globalMemoryLimit: 3372Mi


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
This PR increases the memory for java-mysql devfile so that it won't run into memory issues when running `maven build`. Tested locally and on che.openshift.io.


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15911