### PR TITLE
Update gradle image to use Gradle6; Add user to /etc/group

### DIFF
--- a/arbitrary-users-patch/Dockerfile
+++ b/arbitrary-users-patch/Dockerfile
@@ -3,7 +3,7 @@ FROM ${FROM_IMAGE}
 USER 0
 # Set permissions on /etc/passwd and /home to allow arbitrary users to write
 COPY --chown=0:0 entrypoint.sh /
-RUN mkdir -p /home/user && chgrp -R 0 /home && chmod -R g=u /etc/passwd /home && chmod +x /entrypoint.sh
+RUN mkdir -p /home/user && chgrp -R 0 /home && chmod -R g=u /etc/passwd /etc/group /home && chmod +x /entrypoint.sh
 
 USER 10001
 ENV HOME=/home/user

--- a/arbitrary-users-patch/base_images
+++ b/arbitrary-users-patch/base_images
@@ -1,7 +1,7 @@
 che-cpp-rhel7           registry.access.redhat.com/devtools/llvm-toolset-rhel7
 che-dotnet-2.2          mcr.microsoft.com/dotnet/core/sdk:2.2-stretch
 che-golang-1.12         golang:1.12-stretch
-che-java11-gradle       gradle:5.2.1-jdk11
+che-java11-gradle       gradle:6.2.1-jdk11
 che-java11-maven        maven:3.6.0-jdk-11
 che-java8-maven         maven:3.6.1-jdk-8
 che-nodejs10-community  node:10.16

--- a/arbitrary-users-patch/entrypoint.sh
+++ b/arbitrary-users-patch/entrypoint.sh
@@ -10,10 +10,11 @@ if [ -w "${HOME}" ] && [ ! -f "${HOME}"/.bashrc ]; then
   echo "PS1='\s-\v \w \$ '" > "${HOME}"/.bashrc
 fi
 
-# Add current (arbitrary) user to /etc/passwd
+# Add current (arbitrary) user to /etc/passwd and /etc/group
 if ! whoami &> /dev/null; then
   if [ -w /etc/passwd ]; then
     echo "${USER_NAME:-user}:x:$(id -u):0:${USER_NAME:-user} user:${HOME}:/bin/bash" >> /etc/passwd
+    echo "${USER_NAME:-user}:x:$(id -u):" >> /etc/group
   fi
 fi
 

--- a/devfiles/java-gradle/meta.yaml
+++ b/devfiles/java-gradle/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: Java Gradle
-description: Java Stack with OpenJDK 11 and Gradle 5.2.1
+description: Java Stack with OpenJDK 11 and Gradle 6.2.1
 tags: ["Java", "OpenJDK", "Gradle", "Ubuntu"]
 icon: /images/java.svg
 globalMemoryLimit: 2674Mi


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Updates **che-java11-gradle** image to use Gradle v.6.2.1;
Patches `/etc/group` by adding arbitrary user

@amisevsk @nickboldt I added current arbitrary user into /etc/group because I got a message after opening the terminal:
` groups: cannot find name for group ID 1000160000`
Any concerns of that?

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15723