### PR TITLE
Support sparseCheckoutDir for offline cached projects

### DIFF
--- a/build/scripts/cache_projects.sh
+++ b/build/scripts/cache_projects.sh
@@ -26,14 +26,22 @@ TEMP_REPO="${TEMP_DIR}/cloned"
 #   $1 - URL of git repo
 #   $2 - branch to archive
 #   $3 - destination path for the archived project zip file
+#   $4 - sparse checkout directory
 function cache_project() {
   local repo="$1"
   local branch="$2"
   local destination="$3"
+  local sparse_checkout_dir="$4"
+
   rm -fr "$TEMP_REPO"
   git clone "$repo" -b "$branch" --depth 1 "$TEMP_REPO" -q
   pushd "$TEMP_REPO" &>/dev/null
-    git archive "$branch" -o "$destination"
+    if [ -n "$sparse_checkout_dir" ]; then
+      echo "    Using sparse checkout dir '$sparse_checkout_dir'"
+      git archive -9 "$branch" "$sparse_checkout_dir" -o "$destination"
+    else 
+      git archive -9 "$branch" -o "$destination"
+    fi
   popd &>/dev/null
   rm -rf "$TEMP_REPO"
 }
@@ -108,12 +116,17 @@ for devfile in "${devfiles[@]}"; do
     if [[ ! "$branch" ]] || [[ "$branch" == "null" ]]; then
       branch="master"
     fi
+    sparse_checkout_dir=$(echo "$project" | jq -r '.source.sparseCheckoutDir')
+    if [[ ! "$sparse_checkout_dir" ]] || [[ "$sparse_checkout_dir" == "null" ]]; then
+      unset sparse_checkout_dir
+    fi
+
     # echo "    Caching project $project_name from branch $branch"
     destination="${RESOURCES_DIR}/${devfile_name}-${project_name}-${branch}.zip"
     absolute_destination=$(realpath "$destination")
     # echo "    Caching project to $absolute_destination"
     echo "    Caching project from $location/blob/${branch} to $destination"
-    cache_project "$location" "$branch" "$absolute_destination"
+    cache_project "$location" "$branch" "$absolute_destination" "$sparse_checkout_dir"
 
     echo "    Updating devfile $devfile to point at cached project zip $destination"
     update_devfile "$devfile" "$project_name" "$destination"

--- a/devfiles/quarkus/devfile.yaml
+++ b/devfiles/quarkus/devfile.yaml
@@ -8,7 +8,7 @@ projects:
     source:
       type: git
       location: "https://github.com/quarkusio/quarkus-quickstarts.git"
-      sparseCheckoutDir: /getting-started/
+      sparseCheckoutDir: getting-started
 components:
   -
     type: chePlugin


### PR DESCRIPTION
### What does this PR do?
Support the `sparseCheckoutDir` option when caching offline projects. Turns out it's not hard to do (though it took some time before I noticed the option in `git-archive`...)

### What issues does this PR fix or reference?
Camel-k stack has additional commands present in Theia due to package.json files elsewhere in the repo.