### PR TITLE
Use golang tool with non go modules mod to fix intelligence

### DIFF
--- a/devfiles/go/devfile.yaml
+++ b/devfiles/go/devfile.yaml
@@ -15,6 +15,9 @@ components:
   id: ms-vscode/go/latest
   alias: go-plugin
   memoryLimit: 512Mi
+  env:
+    - value: 'off'
+      name: GO111MODULE
   preferences:
     go.lintTool: 'golangci-lint'
     go.lintFlags: '--fast'


### PR DESCRIPTION
### What does this PR do?
Use golang tool with non go modules to fix file imports intelligence, because we are using sample without go modules.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16427

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>