### PR TITLE
Update PHP base image

### DIFF
--- a/arbitrary-users-patch/base_images
+++ b/arbitrary-users-patch/base_images
@@ -7,7 +7,7 @@ che-java8-maven         maven:3.6.1-jdk-8
 che-nodejs10-community  node:10.16
 che-nodejs10-ubi        registry.access.redhat.com/ubi8/nodejs-10
 che-nodejs8-centos      registry.centos.org/che-stacks/centos-nodejs
-che-php-7               eclipse/php:7.1-che7
+che-php-7               quay.io/eclipse/che-php-base:7.4
 che-python-3.6          centos/python-36-centos7:1
 che-python-3.7          python:3.7.4-slim
 che-quarkus             quay.io/quarkus/centos-quarkus-maven:19.2.1


### PR DESCRIPTION
Update base image for PHP to that which is located in che-dockerfiles/che-php-base.

See eclipse/che#15854

Signed-off-by: Eric Williams <ericwill@redhat.com>