### PR TITLE
CRW-653 support optional extra processing to check backup registries

### DIFF
--- a/build/scripts/write_image_digests.sh
+++ b/build/scripts/write_image_digests.sh
@@ -8,6 +8,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
+SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
 LOG_FILE="/tmp/image_digests.log"
 
 function handle_error() {
@@ -24,10 +25,10 @@ for image in $(yq -r '.components[]?.image' "${devfiles[@]}" | grep -v "null" | 
     echo "    $digest # ${image}"
   else 
     # for other build methods or for falling back to other registries when not found, can apply transforms here
-    if [[ -x "$(dirname "$0")/write_image_digests_alternate_urls.sh" ]]; then
+    if [[ -x "${SCRIPT_DIR}/write_image_digests_alternate_urls.sh" ]]; then
       # since extension file may not exist, disable this check
-      # shellcheck disable=SC1090,SC1091
-      source "$(dirname "$0")/write_image_digests_alternate_urls.sh"
+      # shellcheck disable=SC1090
+      source "${SCRIPT_DIR}/write_image_digests_alternate_urls.sh"
     fi
   fi
 

--- a/build/scripts/write_image_digests.sh
+++ b/build/scripts/write_image_digests.sh
@@ -26,7 +26,7 @@ for image in $(yq -r '.components[]?.image' "${devfiles[@]}" | grep -v "null" | 
     # for other build methods or for falling back to other registries when not found, can apply transforms here
     if [[ -x "$(dirname "$0")/write_image_digests_alternate_urls.sh" ]]; then
       # since extension file may not exist, disable this check
-      # shellcheck disable=SC1091
+      # shellcheck disable=SC1090,SC1091
       source "$(dirname "$0")/write_image_digests_alternate_urls.sh"
     fi
   fi

--- a/build/scripts/write_image_digests.sh
+++ b/build/scripts/write_image_digests.sh
@@ -25,7 +25,8 @@ for image in $(yq -r '.components[]?.image' "${devfiles[@]}" | grep -v "null" | 
   else 
     # for other build methods or for falling back to other registries when not found, can apply transforms here
     if [[ -x "$(dirname "$0")/write_image_digests_alternate_urls.sh" ]]; then
-      # shellcheck source=./build/scripts/util.sh
+      # since extension file may not exist, disable this check
+      # shellcheck disable=SC1091
       source "$(dirname "$0")/write_image_digests_alternate_urls.sh"
     fi
   fi


### PR DESCRIPTION
CRW-653 support optional extra processing to check backup registries; tweak console output to report digest and source image if successful, and which image failed if skipping

Change-Id: Ic47c1349ad7172438e54839e04ee9e800e291037
Signed-off-by: nickboldt <nboldt@redhat.com>