### PR TITLE
Use 20.0.0-java8 tag of centos-quarkus-maven

### DIFF
--- a/arbitrary-users-patch/base_images
+++ b/arbitrary-users-patch/base_images
@@ -10,5 +10,5 @@ che-nodejs8-centos      registry.centos.org/che-stacks/centos-nodejs
 che-php-7               quay.io/eclipse/che-php-base:7.4
 che-python-3.6          centos/python-36-centos7:1
 che-python-3.7          python:3.7.4-slim
-che-quarkus             quay.io/quarkus/centos-quarkus-maven:19.2.1
+che-quarkus             quay.io/quarkus/centos-quarkus-maven:20.0.0-java8
 che-rust-1.39           rust:1.39.0-slim

--- a/devfiles/quarkus/meta.yaml
+++ b/devfiles/quarkus/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: Quarkus Tools
-description: Quarkus Tools with OpenJDK 8 and Maven 3.6.0
+description: Quarkus Tools with OpenJDK 8 and Maven 3.6.3
 tags: ["Java", "Quarkus", "OpenJDK", "Maven", "Debian"]
 icon: /images/quarkus.svg
 globalMemoryLimit: 2674Mi


### PR DESCRIPTION
Use latest tag of centos-quarkus-maven: 20.0.0-java8
Needed to have native compilation working with the default Quarkus sample