### PR TITLE
Fix memoryLimit to Mi instead of Mib since the latest is not valid anymore

### DIFF
--- a/devfiles/java-mongo/devfile.yaml
+++ b/devfiles/java-mongo/devfile.yaml
@@ -12,7 +12,7 @@ components:
 -
   type: chePlugin
   id: redhat/java/latest
-  memoryLimit: 1280MiB
+  memoryLimit: 1280Mi
 -
   type: dockerimage
   alias: maven

--- a/devfiles/java-mysql/devfile.yaml
+++ b/devfiles/java-mysql/devfile.yaml
@@ -13,7 +13,7 @@ components:
   -
     type: chePlugin
     id: redhat/java/latest
-    memoryLimit: 1280MiB
+    memoryLimit: 1280Mi
   -
     type: dockerimage
     alias: tools


### PR DESCRIPTION
### What does this PR do?
Fix memoryLimit to Mi instead of Mib since the latest is not valid anymore

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16572