### PR TITLE
che #16583 Applying memory limit fixes for mysql & mongo devfiles

### DIFF
--- a/devfiles/java-mongo/devfile.yaml
+++ b/devfiles/java-mongo/devfile.yaml
@@ -12,7 +12,7 @@ components:
 -
   type: chePlugin
   id: redhat/java/latest
-  memoryLimit: 1280MiB
+  memoryLimit: 1280Mi
 -
   type: dockerimage
   alias: maven

--- a/devfiles/java-mysql/devfile.yaml
+++ b/devfiles/java-mysql/devfile.yaml
@@ -13,7 +13,7 @@ components:
   -
     type: chePlugin
     id: redhat/java/latest
-    memoryLimit: 1280MiB
+    memoryLimit: 1280Mi
   -
     type: dockerimage
     alias: tools


### PR DESCRIPTION
Applying memory limit fixes for mysql & mongo devfiles.
PR for master - https://github.com/eclipse/che-devfile-registry/pull/224 from @mingfang 

### What does this PR do?
Applying memory limit fixes for mysql & mongo devfiles

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16583