### PR TITLE
dev mode + ./mvnw for quarkus

### DIFF
--- a/devfiles/quarkus/devfile.yaml
+++ b/devfiles/quarkus/devfile.yaml
@@ -44,15 +44,15 @@ commands:
       -
         type: exec
         component: maven
-        command: "mvn package"
+        command: "./mvnw package"
         workdir: ${CHE_PROJECTS_ROOT}/quarkus-quickstarts/getting-started
   -
-    name: Start development server
+    name: Start Development mode
     actions:
       -
         type: exec
         component: maven
-        command: "mvn compile quarkus:dev"
+        command: "./mvnw compile quarkus:dev"
         workdir: ${CHE_PROJECTS_ROOT}/quarkus-quickstarts/getting-started
   -
     name: Attach remote debugger


### PR DESCRIPTION
Why:

 * "Development server" is not the right term for quarkus:dev (since 1.4
   there command mode which is not a server.
 * All Quarkus apps and examples by default comes with mvn wrapper. That
   should be the default used.

This change addreses the need by:

 * Make 'development server' 'Development mode"
 * Update tasks to use `./mvnw` instead of `mvn`


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16701
