### PR TITLE
Quick fix .net core stack endpoint name so it picks the right url in the preview pane

### DIFF
--- a/devfiles/dotnet/devfile.yaml
+++ b/devfiles/dotnet/devfile.yaml
@@ -26,7 +26,7 @@ components:
     image: quay.io/eclipse/che-dotnet-2.2:nightly
     memoryLimit: 512Mi
     endpoints:
-      - name: '5000/tcp'
+      - name: '5000-tcp'
         port: 5000
     mountSources: true
     volumes:


### PR DESCRIPTION
quick fix https://github.com/eclipse/che/issues/16748
original issue: https://github.com/eclipse/che/issues/16381

