### PR TITLE
Use the quarkus java11 image in our quarkus stack

### DIFF
--- a/arbitrary-users-patch/base_images
+++ b/arbitrary-users-patch/base_images
@@ -10,5 +10,5 @@ che-nodejs8-centos      registry.centos.org/che-stacks/centos-nodejs
 che-php-7               quay.io/eclipse/che-php-base:7.4
 che-python-3.6          centos/python-36-centos7:1
 che-python-3.7          python:3.7.4-slim
-che-quarkus             quay.io/quarkus/centos-quarkus-maven:20.0.0-java8
+che-quarkus             quay.io/quarkus/centos-quarkus-maven:20.0.0-java11
 che-rust-1.39           rust:1.39.0-slim


### PR DESCRIPTION
Using 20.0.0-java11 instead of 20.0.0-java8 centos-quarkus-maven https://quay.io/repository/quarkus/centos-quarkus-maven?tag=20.0.0-java11&tab=tags

Partly solving https://github.com/eclipse/che/issues/16790