### PR TITLE
Allow user to add TLS certificates to Java Keystore

### DIFF
--- a/arbitrary-users-patch/Dockerfile
+++ b/arbitrary-users-patch/Dockerfile
@@ -2,8 +2,15 @@ ARG FROM_IMAGE
 FROM ${FROM_IMAGE}
 USER 0
 # Set permissions on /etc/passwd and /home to allow arbitrary users to write
-COPY --chown=0:0 entrypoint.sh /
-RUN mkdir -p /home/user && chgrp -R 0 /home && chmod -R g=u /etc/passwd /etc/group /home && chmod +x /entrypoint.sh
+COPY [--chown=0:0] entrypoint.sh /
+COPY [--chown=0:0] change-trust-store-permissions.sh /usr/bin
+RUN mkdir -p /home/user && \
+      chgrp -R 0 /home && \
+      chmod -R g=u /etc/passwd /home && \
+      chmod +x /entrypoint.sh && \
+      chmod +x /usr/bin/change-trust-store-permissions.sh && \
+      /usr/bin/change-trust-store-permissions.sh && \
+      rm /usr/bin/change-trust-store-permissions.sh
 
 USER 10001
 ENV HOME=/home/user

--- a/arbitrary-users-patch/change-trust-store-permissions.sh
+++ b/arbitrary-users-patch/change-trust-store-permissions.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [[ -n "$JAVA_HOME" ]]; then
+  if [[ -f "$JAVA_HOME/jre/lib/security/cacerts" ]]; then
+    chmod 664 "$JAVA_HOME/jre/lib/security/cacerts"
+  fi
+fi


### PR DESCRIPTION

### What does this PR do?

Fixes https://github.com/eclipse/che/issues/16920.

This adds a script that checks if `$JAVA_HOME` and the `cacerts` file exists, and if it does, sets the permissions of it to `664`, and then removes the script from the image.

### What issues does this PR fix or reference?
