### PR TITLE
Include referenced images from referenced kubernetes content to external_images.txt

### DIFF
--- a/build/scripts/list_referenced_images.sh
+++ b/build/scripts/list_referenced_images.sh
@@ -14,3 +14,7 @@ set -e
 
 readarray -d '' devfiles < <(find "$1" -name 'devfile.yaml' -print0)
 yq -r '..|.image?' "${devfiles[@]}" | grep -v "null" | sort | uniq
+# include images from referenced kubernetes content.
+for devfile in "${devfiles[@]}"; do
+    yq -r '.components[] | .referenceContent?' "${devfile}" | yq -r '.items?|..|.image?' | grep -v "null" | sort | uniq
+done


### PR DESCRIPTION
### What does this PR do?
Include referenced images from referenced kubernetes content to external_images.txt. Actual after merge: https://github.com/eclipse/che-devfile-registry/pull/147

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16815

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>