### PR TITLE
update maven to latest 3.6.3

### DIFF
--- a/arbitrary-users-patch/base_images
+++ b/arbitrary-users-patch/base_images
@@ -2,7 +2,7 @@ che-cpp-rhel7           registry.access.redhat.com/devtools/llvm-toolset-rhel7
 che-dotnet-2.2          mcr.microsoft.com/dotnet/core/sdk:2.2-stretch
 che-golang-1.12         golang:1.12-stretch
 che-java11-gradle       gradle:6.2.1-jdk11
-che-java11-maven        maven:3.6.0-jdk-11
+che-java11-maven        maven:3.6.3-jdk-11
 che-java8-maven         maven:3.6.1-jdk-8
 che-nodejs10-community  node:10.16
 che-nodejs10-ubi        registry.access.redhat.com/ubi8/nodejs-10


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Updates maven base image to latest v3.6.3. We need this to be able to build che-server in Che.

### What issues does this PR fix or reference?
che-server dogfooding