### PR TITLE
Fix offline build failures

### DIFF
--- a/devfiles/java-web-spring/devfile.yaml
+++ b/devfiles/java-web-spring/devfile.yaml
@@ -8,6 +8,7 @@ projects:
     source:
       type: git
       location: "https://github.com/spring-projects/spring-petclinic.git"
+      branch: main
 components:
   -
     type: chePlugin


### PR DESCRIPTION

### What does this PR do?

Fix failures on `./build.sh --offline`.

This have two fixes.

1. Support `.source.commitId` on Devfiles.  It is used in `java-mysql-web-java-spring-petclinic`.
2. Specify `main` branch in `java-web-spring`. There is no `master` branch in the source repository.

### What issues does this PR fix or reference?

None.
