### PR TITLE
Add new image for golang 1.14

### DIFF
--- a/arbitrary-users-patch/base_images
+++ b/arbitrary-users-patch/base_images
@@ -1,6 +1,7 @@
 che-cpp-rhel7           registry.access.redhat.com/devtools/llvm-toolset-rhel7
 che-dotnet-2.2          mcr.microsoft.com/dotnet/core/sdk:2.2-stretch
 che-golang-1.12         golang:1.12-stretch
+che-golang-1.14         golang:1.14-stretch
 che-java11-gradle       gradle:6.2.1-jdk11
 che-java11-maven        maven:3.6.3-jdk-11
 che-java8-maven         maven:3.6.1-jdk-8


### PR DESCRIPTION
### What does this PR do?

This PR add a new docker image for golang version 1.14