### PR TITLE
[java-web-spring] Use che-java11-maven:nighty instead of Java8.

### DIFF
--- a/devfiles/java-web-spring/devfile.yaml
+++ b/devfiles/java-web-spring/devfile.yaml
@@ -16,7 +16,7 @@ components:
   -
     type: dockerimage
     alias: tools
-    image: quay.io/eclipse/che-java8-maven:nightly
+    image: quay.io/eclipse/che-java11-maven:nightly
     env:
       - name: MAVEN_CONFIG
         value: ""


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>

### What does this PR do?

Uses `eclipse/che-java11-maven:nightly` image instead of `eclipse/che-java8-maven:nightly`
I checked code can be built and run with Java11 by hand.

### What issues does this PR fix or reference?

None.
