### PR TITLE
Update quarkus devfile: using ubi-minimal

### DIFF
--- a/devfiles/quarkus/devfile.yaml
+++ b/devfiles/quarkus/devfile.yaml
@@ -37,8 +37,8 @@ components:
           path: /hello/greeting/che-user
 
   - type: dockerimage
-    alias: ubi-quarkus-native-image
-    image: 'quay.io/quarkus/ubi-quarkus-native-image:19.2.0.1'
+    alias: ubi-minimal
+    image: 'registry.access.redhat.com/ubi8/ubi-minimal'
     memoryLimit: 32M
     mountSources: true
     endpoints:
@@ -80,7 +80,7 @@ commands:
     actions:
       -
         type: exec
-        component: ubi-quarkus-native-image
+        component: ubi-minimal
         command: ./getting-started-1.0-SNAPSHOT-runner
         workdir: ${CHE_PROJECTS_ROOT}/quarkus-quickstarts/getting-started/target
   -


### PR DESCRIPTION

### What does this PR do?
The native image from quarkus is to build the native image not to run it. Similar to centos-quarkus-maven.
This is fixing it using ubi-minimal

