### PR TITLE
Updating quarkus stack description: Maven 3.6.3 and jdk11

### DIFF
--- a/devfiles/quarkus/meta.yaml
+++ b/devfiles/quarkus/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: Quarkus Tools
-description: Quarkus Tools with OpenJDK 8 and Maven 3.6.3
+description: Quarkus Tools with OpenJDK 11 and Maven 3.6.3
 tags: ["Java", "Quarkus", "OpenJDK", "Maven", "Debian"]
 icon: /images/quarkus.svg
 globalMemoryLimit: 2674Mi


### PR DESCRIPTION
### What does this PR do?
Updating quarkus stack description

![image](https://user-images.githubusercontent.com/650571/86328971-d3c6ae00-bc45-11ea-87c4-17413801121b.png)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17311
