### PR TITLE
feat(java11): Bump tooling to java11 as well

### DIFF
--- a/devfiles/java-web-spring/devfile.yaml
+++ b/devfiles/java-web-spring/devfile.yaml
@@ -11,7 +11,7 @@ projects:
 components:
   -
     type: chePlugin
-    id: redhat/java/latest
+    id: redhat/java11/latest
     memoryLimit: 1512Mi
   -
     type: dockerimage


### PR DESCRIPTION
### What does this PR do?
bump java to java11 for tooling as well

![image](https://user-images.githubusercontent.com/436777/86358594-05ed0580-bc70-11ea-9701-cbdf6edf2f6a.png)


Can be tested with http://che.openshift.io/f/?url=https://raw.githubusercontent.com/benoitf/che-devfile-registry/bump-java11/devfiles/java-web-spring/devfile.yaml

Change-Id: I50257b0d456c54a19985aa1735abcea47974572c
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

