### PR TITLE
fix(version): 8-->11

### DIFF
--- a/devfiles/java-web-spring/meta.yaml
+++ b/devfiles/java-web-spring/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: Java Spring Boot
-description: Java stack with OpenJDK 8 and Spring Boot Petclinic demo application
+description: Java stack with OpenJDK 11 and Spring Boot Petclinic demo application
 tags: ["Java", "OpenJDK", "Maven", "Spring Boot"]
 icon: /images/springboot.svg
 globalMemoryLimit: 3072Mi


### PR DESCRIPTION
### What does this PR do?
Stacks was updated to use Java 11 and not java8, updating description

### What issues does this PR fix or reference?
https://github.com/eclipse/che-devfile-registry/pull/257