### PR TITLE
update quarkus image to use GraalVM 20.1.0.

### DIFF
--- a/arbitrary-users-patch/base_images
+++ b/arbitrary-users-patch/base_images
@@ -12,5 +12,5 @@ che-nodejs8-centos      registry.centos.org/che-stacks/centos-nodejs
 che-php-7               quay.io/eclipse/che-php-base:7.4
 che-python-3.6          centos/python-36-centos7:1
 che-python-3.7          python:3.7.4-slim
-che-quarkus             quay.io/quarkus/centos-quarkus-maven:20.0.0-java11
+che-quarkus             quay.io/quarkus/centos-quarkus-maven:20.1.0-java11
 che-rust-1.39           rust:1.39.0-slim


### PR DESCRIPTION
New version of Quarkus currently supports GraalVM 19.3.2 and 20.1.0.

![image](https://user-images.githubusercontent.com/650571/87939654-a88eec00-ca98-11ea-8274-75fdd19cb7a4.png)
