### PR TITLE
Add sample project to Go stack

### DIFF
--- a/devfiles/go/devfile.yaml
+++ b/devfiles/go/devfile.yaml
@@ -9,10 +9,21 @@ projects:
     type: git
     location: https://github.com/golang/example.git
   clonePath: src/github.com/golang/example/
+-
+  name: golang-echo-realworld-example-app
+  source:
+    type: git
+    location: https://github.com/xesina/golang-echo-realworld-example-app.git
+  clonePath: src/github.com/xesina/golang-echo-realworld-example-app
+
 components:
 -
+  type: cheEditor
+  id: eclipse/che-theia/next
+  memoryLimit: 1Gi
+-
   type: chePlugin
-  id: ms-vscode/go/latest
+  id: golang/go/latest
   alias: go-plugin
   memoryLimit: 512Mi
   env:
@@ -25,12 +36,12 @@ components:
 -
   type: dockerimage
   # this version is used in the plugin
-  image: quay.io/eclipse/che-golang-1.12:nightly
+  image: quay.io/eclipse/che-golang-1.14:nightly
   alias: go-cli
   env:
     - name: GOPATH
       # replicate the GOPATH from the plugin
-      value: /go:$(CHE_PROJECTS_ROOT)
+      value: $(CHE_PROJECTS_ROOT)
     - name: GOCACHE
       # replicate the GOCACHE from the plugin, even though the cache is not shared
       # between the two
@@ -38,38 +49,66 @@ components:
   endpoints:
     - name: '8080-tcp'
       port: 8080
-  memoryLimit: 512Mi
+  memoryLimit: 2Gi
   mountSources: true
 commands:
 -
-  name: run outyet
+  name: '1.1 Run outyet'
   actions:
   - type: exec
     component: go-cli
     command: go get -d && go run main.go
     workdir: ${CHE_PROJECTS_ROOT}/src/github.com/golang/example/outyet
 -
-  name: stop outyet
+  name: '1.2 Stop outyet'
   actions:
   - type: exec
     component: go-cli
     command: kill $(pidof go)
 -
-  name: test outyet
+  name: '1.3 Test outyet'
   actions:
   - type: exec
     component: go-cli
     command: go test
     workdir: ${CHE_PROJECTS_ROOT}/src/github.com/golang/example/outyet
 -
-  name: run current file
+  name: '2.1 xenisa :: install dependencies'
+  actions:
+  - type: exec
+    component: go-cli
+    command: go mod download
+    workdir: ${GOPATH}/src/github.com/xesina/golang-echo-realworld-example-app
+-
+  name: '2.2 xenisa :: run'
+  actions:
+  - type: exec
+    component: go-cli
+    command: go run main.go
+    workdir: ${GOPATH}/src/github.com/xesina/golang-echo-realworld-example-app
+-
+  name: '2.3 xenisa :: build'
+  actions:
+  - type: exec
+    component: go-cli
+    command: go build
+    workdir: ${GOPATH}/src/github.com/xesina/golang-echo-realworld-example-app
+-
+  name: '2.4 xenisa :: test'
+  actions:
+  - type: exec
+    component: go-cli
+    command: go test ./...
+    workdir: ${GOPATH}/src/github.com/xesina/golang-echo-realworld-example-app
+-
+  name: 'Run current file'
   actions:
   - type: exec
     component: go-cli
     command: go get -d && go run ${file}
     workdir: ${fileDirname}
 -
-  name: Debug current file
+  name: 'Debug current file'
   actions:
   - type: vscode-launch
     referenceContent: |


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Adds another one sample project to Go stack.
Adds commands to build and run sample project.

If the `golang/go` plugin could not be found when creating a workspace from the devfile, the `id` should be replaced on `reference`.
```
-
  type: chePlugin
  # id: golang/go/latest
  reference: >-
    https://raw.githubusercontent.com/eclipse/che-plugin-registry/master/v3/plugins/golang/go/0.14.4/meta.yaml
  alias: go-plugin
  memoryLimit: 512Mi
  # memoryLimit: 1Gi
  env:
    - value: 'off'
      name: GO111MODULE
  preferences:
    go.lintTool: 'golangci-lint'
    go.lintFlags: '--fast'
    go.useLanguageServer: true
```

### What issues does this PR fix or reference?

Solves issue https://github.com/eclipse/che/issues/13803
