### PR TITLE
Switch to quarkus-java11 by default

### DIFF
--- a/devfiles/quarkus/devfile.yaml
+++ b/devfiles/quarkus/devfile.yaml
@@ -12,7 +12,7 @@ projects:
 components:
   -
     type: chePlugin
-    id: redhat/quarkus-java8/latest
+    id: redhat/quarkus-java11/latest
   -
     type: dockerimage
     alias: centos-quarkus-maven


### PR DESCRIPTION
Closes eclipse/che#16790

Signed-off-by: Eric Williams <ericwill@redhat.com>
