### PR TITLE
Check container images digest in PRs

### DIFF
--- a/.ci/devfile-images-check.sh
+++ b/.ci/devfile-images-check.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Copyright (c) 2012-2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+set -e
+
+# PR_FILES_CHANGED store all Modified/Created files in Pull Request.
+export PR_FILES_CHANGED=$(git --no-pager diff --name-only HEAD $(git merge-base HEAD origin/master))
+
+# filterDevFileYamls function filter yamls from PR into a new array => FILES_CHANGED_ARRAY.
+function filterDevFileYamls() {
+    export SCRIPT=$(readlink -f "$0")
+    export ROOT_DIR=$(dirname $(dirname "$SCRIPT"));
+
+    for files in ${PR_FILES_CHANGED}
+    do  
+        # Filter only files which are devfiles folder and finish with .yaml extension
+        if [[ $files =~ ^devfiles.*.yaml$ ]]; then
+            echo "[INFO] Added/Changed new devfile in the current PR: ${files}"
+            export FILES_CHANGED_ARRAY+=("${ROOT_DIR}/"$files)
+        fi
+    done 
+}
+
+# checkDevFileImages get the container images from changed devfile.yaml files in PR and check if they have digest.
+function checkDevFileImages() {
+    export IMAGES=$(yq -r '..|.image?' "${FILES_CHANGED_ARRAY[@]}" | grep -v "null" | uniq)
+
+    for image in ${IMAGES}
+    do
+        local DIGEST="$(skopeo inspect --tls-verify=false docker://${image} 2>/dev/null | jq -r '.Digest')"
+        if [ -z "${DIGEST}" ];
+        then
+            echo "[ERROR] Image ${image} doesn't contain an valid digest.Digest check script will fail."
+            exit 1
+        fi
+        echo "[INFO] Successfully checked image digest: ${image}"
+    done
+}
+
+filterDevFileYamls
+checkDevFileImages

--- a/.ci/devfile-images-check.sh
+++ b/.ci/devfile-images-check.sh
@@ -12,30 +12,38 @@
 set -e
 
 # PR_FILES_CHANGED store all Modified/Created files in Pull Request.
-export PR_FILES_CHANGED=$(git --no-pager diff --name-only HEAD $(git merge-base HEAD origin/master))
+PR_FILES_CHANGED=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD origin/master)")
+export PR_FILES_CHANGED
 
 # filterDevFileYamls function filter yamls from PR into a new array => FILES_CHANGED_ARRAY.
 function filterDevFileYamls() {
-    export SCRIPT=$(readlink -f "$0")
-    export ROOT_DIR=$(dirname $(dirname "$SCRIPT"));
+    local SCRIPT
+    SCRIPT=$(readlink -f "$0")
+
+    local ROOT_DIR
+    ROOT_DIR=$(dirname "$(dirname "$SCRIPT")");
 
     for files in ${PR_FILES_CHANGED}
     do  
         # Filter only files which are devfiles folder and finish with .yaml extension
         if [[ $files =~ ^devfiles.*.yaml$ ]]; then
             echo "[INFO] Added/Changed new devfile in the current PR: ${files}"
-            export FILES_CHANGED_ARRAY+=("${ROOT_DIR}/"$files)
+            FILES_CHANGED_ARRAY+=("${ROOT_DIR}/"$files)
+            export FILES_CHANGED_ARRAY
         fi
     done 
 }
 
 # checkDevFileImages get the container images from changed devfile.yaml files in PR and check if they have digest.
 function checkDevFileImages() {
-    export IMAGES=$(yq -r '..|.image?' "${FILES_CHANGED_ARRAY[@]}" | grep -v "null" | uniq)
+    IMAGES=$(yq -r '..|.image?' "${FILES_CHANGED_ARRAY[@]}" | grep -v "null" | uniq)
+    export IMAGES
 
     for image in ${IMAGES}
     do
-        local DIGEST="$(skopeo inspect --tls-verify=false docker://${image} 2>/dev/null | jq -r '.Digest')"
+
+        local DIGEST
+        DIGEST="$(skopeo inspect --tls-verify=false docker://"${image}" 2>/dev/null | jq -r '.Digest')"
         if [ -z "${DIGEST}" ];
         then
             echo "[ERROR] Image ${image} doesn't contain an valid digest.Digest check script will fail."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,16 @@ jobs:
         run: |
           find . -type f -name '*.sh' | wc -l
           find . -type f -name '*.sh' | xargs shellcheck --external-sources
+
+  digest-validation:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run script which checks container image digest
+      run: |
+        sudo pip install yq
+        /bin/bash .ci/devfile-images-check.sh
+
   build:
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: flacatus <flacatus@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
This PR create a new ci script which basically check all new container images created/changed in the `devfile.yaml` files. This CI scripts will run using github actions. The job name is `digest-validation`.

I tested this job in one of my repo: https://github.com/flacatus/github-actions/pull/4

### What issues does this PR fix or reference?

Reference issue: https://github.com/eclipse/che/issues/17368