### PR TITLE
Cache images in browser cache for 1 day

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -5,7 +5,7 @@ DirectoryIndex README.md
 AddType image/svg+xml svg svgz
 AddEncoding gzip svgz
 
-<FilesMatch "\.(json|yaml|svg|png)$">
+<FilesMatch "\.(json|yaml)$">
 
   <IfModule mod_expires.c>
     ExpiresActive Off
@@ -21,4 +21,14 @@ AddEncoding gzip svgz
     Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
     Header set Expires "Mon, 10 Apr 1972 00:00:00 GMT"
   </IfModule>
+</FilesMatch>
+
+<FilesMatch "\.(svg|png)$">
+
+  <IfModule mod_expires.c>
+    ExpiresActive on
+    # Set the default expiry times.
+    ExpiresDefault "access plus 1 days"
+  </IfModule>
+
 </FilesMatch>


### PR DESCRIPTION
### What does this PR do?
This PR makes browser cache devfile images for 1 day.

It's draft since I'm not sure it's the best option to go. Maybe browser should always ask for ETAG.
The first load
![Screenshot_20200731_144201](https://user-images.githubusercontent.com/5887312/89032055-74d78000-d33c-11ea-813b-9adef9637a9f.png)

All next until tomorrow)
![Screenshot_20200731_144121](https://user-images.githubusercontent.com/5887312/89032064-7b65f780-d33c-11ea-8161-c30e272464b6.png)

### What are alternatives?

1. Use etags to validate browser cache. It's needed to make sure that it won't lead to container memory consumption.

2. Use hard caching but on the container build phase - rename images to contains their hashes, so, images will be redownloaded after they are changed.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16296
