### PR TITLE
Remove bitlang cobol from Che4z

### DIFF
--- a/devfiles/che4z/devfile.yaml
+++ b/devfiles/che4z/devfile.yaml
@@ -8,9 +8,6 @@ components:
     id: broadcommfd/cobol-language-support/latest
   - 
     type: chePlugin
-    id: bitlang/cobol/latest
-  - 
-    type: chePlugin
     id: broadcommfd/explorer-for-endevor/latest
   - 
     type: chePlugin


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Remove bitlang cobol plugin from Mainframe Basic Stack

### What issues does this PR fix or reference?

MERGE NOTE: Due to plugin dependencies, please merge this PR together with [https://github.com/eclipse/che-plugin-registry/pull/598](https://github.com/eclipse/che-plugin-registry/pull/598)