### PR TITLE
Use latest CDT plugin.

### DIFF
--- a/devfiles/cpp/devfile.yaml
+++ b/devfiles/cpp/devfile.yaml
@@ -9,19 +9,14 @@ projects:
       type: git
       location: 'https://github.com/che-samples/cpp-hello-world'
 components:
--
-  type: chePlugin
-  id: che-incubator/cpptools/latest
-  alias: cpp-plugin
-  preferences:
-    clangd.path: /usr/bin/clangd
-    cdt.clangd.binaries.enable: false
--
-  type: dockerimage
-  alias: cpp-dev
-  image: quay.io/eclipse/che-cpp-rhel7:nightly
-  memoryLimit: 512Mi
-  mountSources: true
+  - type: chePlugin
+    id: eclipse-cdt/cdt-vscode/latest
+    alias: cpp-plugin
+  - type: dockerimage
+    alias: cpp-dev
+    image: quay.io/eclipse/che-cpp-rhel7:nightly
+    memoryLimit: 512Mi
+    mountSources: true
 commands:
   -
     name: build


### PR DESCRIPTION

### What does this PR do?

Uses `eclipse-cdt/cdt-vscode/latest` instead of `che-incubator/cpptools/latest`.  It is deprecated.

### What issues does this PR fix or reference?

None.