### PR TITLE
[Golang] Remove cheEditor from components.

### DIFF
--- a/devfiles/go/devfile.yaml
+++ b/devfiles/go/devfile.yaml
@@ -18,10 +18,6 @@ projects:
 
 components:
 -
-  type: cheEditor
-  id: eclipse/che-theia/next
-  memoryLimit: 1Gi
--
   type: chePlugin
   id: golang/go/latest
   alias: go-plugin


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>

### What does this PR do?

Removes `cheEditor` from components.
It is redundant because Che will choose its default editor from `CHE_FACTORY_DEFAULT__EDITOR` variable.

### What issues does this PR fix or reference?

None.