### PR TITLE
Update the command of installing dependencies in NodeJS+Yarn devfile

### DIFF
--- a/arbitrary-users-patch/base_images
+++ b/arbitrary-users-patch/base_images
@@ -7,6 +7,7 @@ che-java11-gradle       gradle:6.2.1-jdk11
 che-java11-maven        maven:3.6.3-jdk-11
 che-java8-maven         maven:3.6.1-jdk-8
 che-nodejs10-community  node:10.16
+che-nodejs12-community  node:12.18
 che-nodejs10-ubi        registry.access.redhat.com/ubi8/nodejs-10
 che-nodejs8-centos      registry.centos.org/che-stacks/centos-nodejs
 che-php-7               quay.io/eclipse/che-php-base:7.4

--- a/devfiles/nodejs-yarn/devfile.yaml
+++ b/devfiles/nodejs-yarn/devfile.yaml
@@ -17,7 +17,7 @@ components:
     type: dockerimage
     alias: nodejs
     image: quay.io/eclipse/che-nodejs10-community:nightly
-    memoryLimit: 1Gi
+    memoryLimit: 1500Mi
     endpoints:
       - name: 'nodejs'
         port: 3000
@@ -28,7 +28,7 @@ commands:
     actions:
       - type: exec
         component: nodejs
-        command: yarn install
+        command: npm install
         workdir: ${CHE_PROJECTS_ROOT}/react-web-app
   -
     name: build the app

--- a/devfiles/nodejs-yarn/devfile.yaml
+++ b/devfiles/nodejs-yarn/devfile.yaml
@@ -16,7 +16,7 @@ components:
   -
     type: dockerimage
     alias: nodejs
-    image: quay.io/eclipse/che-nodejs10-community:nightly
+    image: quay.io/eclipse/che-nodejs12-community:nightly
     memoryLimit: 1500Mi
     endpoints:
       - name: 'nodejs'
@@ -24,28 +24,35 @@ components:
     mountSources: true
 commands:
   -
-    name: install all required dependencies
+    name: 1. Install Yarn 2
     actions:
       - type: exec
         component: nodejs
-        command: npm install
+        command: yarn set version berry
         workdir: ${CHE_PROJECTS_ROOT}/react-web-app
   -
-    name: build the app
+    name: 2. Install all required dependencies
+    actions:
+      - type: exec
+        component: nodejs
+        command: yarn install
+        workdir: ${CHE_PROJECTS_ROOT}/react-web-app
+  -
+    name: 3. Build the app
     actions:
       - type: exec
         component: nodejs
         command: yarn build
         workdir: ${CHE_PROJECTS_ROOT}/react-web-app
   -
-    name: run the app
+    name: 4. Run the app
     actions:
       - type: exec
         component: nodejs
         command: yarn start
         workdir: ${CHE_PROJECTS_ROOT}/react-web-app
   -
-    name: launch tests
+    name: 5. Launch tests
     actions:
       - type: exec
         component: nodejs


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Adds more memory for dev container;
Change the command to install dependencies from `yarn install` to `npm instaal`. Looks like yarn cannot install dependencies because the .node_modules was marked as symlink.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17453