### PR TITLE
Add antora to list of UID patch images

### DIFF
--- a/arbitrary-users-patch/base_images
+++ b/arbitrary-users-patch/base_images
@@ -1,3 +1,4 @@
+che-antora-2.3          docker.io/antora/antora:2.3.3
 che-cpp-rhel7           registry.access.redhat.com/devtools/llvm-toolset-rhel7
 che-dotnet-2.2          mcr.microsoft.com/dotnet/core/sdk:2.2-stretch
 che-dotnet-3.1          mcr.microsoft.com/dotnet/core/sdk:3.1.301-buster


### PR DESCRIPTION
### What does this PR do?
Add new UID-patched image for Antora. 

### What issues does this PR fix or reference?
Antora is used for building Che docs, but the [devfile](https://github.com/eclipse/che-docs/blob/3e9b404c0bef89b86546555213ffe0ee1c646799/devfile.yaml#L9) uses the default docker.io repo image, which could encounter UID issues as we've seen in the past.

### Note
If this PR is approved, a repo in quay.io/eclipse must be created for the new image before this PR is merged.