### PR TITLE
Bump gradle to 6.6.1

### DIFF
--- a/arbitrary-users-patch/base_images
+++ b/arbitrary-users-patch/base_images
@@ -3,7 +3,7 @@ che-dotnet-2.2          mcr.microsoft.com/dotnet/core/sdk:2.2-stretch
 che-dotnet-3.1          mcr.microsoft.com/dotnet/core/sdk:3.1.301-buster
 che-golang-1.12         golang:1.12-stretch
 che-golang-1.14         golang:1.14-stretch
-che-java11-gradle       gradle:6.2.1-jdk11
+che-java11-gradle       gradle:6.6.1-jdk11
 che-java11-maven        maven:3.6.3-jdk-11
 che-java8-maven         maven:3.6.1-jdk-8
 che-nodejs10-community  node:10.16


### PR DESCRIPTION
Signed-off-by: Esteban Mañaricua <emanaricua@gmail.com>
when testing example kotlin apps I am using the gradle+jdk11 cli image and I get:
````Gradle
buildscript {
    ext.kotlin_version = '+'
    ext.autoparcel_version = '1.0.1'

    repositories {
        jcenter()
        google()
    }

    dependencies {
        classpath 'com.android.tools.build:gradle:+'
        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
    }
}

````

produces:
````verilog

* What went wrong:
A problem occurred evaluating project ':app'.
> Failed to apply plugin [id 'com.android.internal.version-check']
   > Minimum supported Gradle version is 6.6.1. Current version is 6.2.1. If using the gradle wrapper, try editing the distributionUrl in /projects/kotlin/gradle/android-auto-parcel/gradle/wrapper/gradle-wrapper.properties to gradle-6.6.1-all.zip
````
Signed-off-by: Esteban Mañaricua <emanaricua@gmail.com>
