### PR TITLE
Remove "Tools" from the Quarkus stack name

### DIFF
--- a/devfiles/quarkus/meta.yaml
+++ b/devfiles/quarkus/meta.yaml
@@ -1,6 +1,6 @@
 ---
-displayName: Quarkus Tools
-description: Quarkus Tools with OpenJDK 11 and Maven 3.6.3
+displayName: Quarkus
+description: Quarkus Stack with OpenJDK 11 and Maven 3.6.3
 tags: ["Java", "Quarkus", "OpenJDK", "Maven", "Debian"]
 icon: /images/quarkus.svg
 globalMemoryLimit: 2674Mi


### PR DESCRIPTION
### What does this PR do?

This is how the Quarkus stack appears in the getting started today:

<img width="317" alt="image" src="https://user-images.githubusercontent.com/606959/94270454-58bd1d00-ff40-11ea-9403-e61cf3f0c287.png">

But this is not a "Quarkus Tools" stack. This is a "Quarkus" stack. Hence removing the word "Tools".
