### PR TITLE
Add python 3.8 base image

### DIFF
--- a/arbitrary-users-patch/base_images
+++ b/arbitrary-users-patch/base_images
@@ -13,5 +13,6 @@ che-nodejs8-centos      registry.centos.org/che-stacks/centos-nodejs
 che-php-7               quay.io/eclipse/che-php-base:7.4
 che-python-3.6          centos/python-36-centos7:1
 che-python-3.7          python:3.7.4-slim
+che-python-3.8          python:3.8-6-slim
 che-quarkus             quay.io/quarkus/centos-quarkus-maven:20.1.0-java11
 che-rust-1.39           rust:1.39.0-slim


### PR DESCRIPTION
### What does this PR do?
Adds a base image for python devfiles using python 3.8.6

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16183