### PR TITLE
chore(github): Update the template to match new definition of done on PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,43 @@
 <!-- Please review the following before submitting a PR:
 Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
 Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-
 -->
 
 ### What does this PR do?
 
 
+### Screenshot/screencast of this PR
+<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
+
+
 ### What issues does this PR fix or reference?
+<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
+     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
+-->
+
+
+### How to test this PR?
+<!-- Please explain for example :
+  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
+  - Installation method: chectl / che-operator
+  - steps to reproduce
+ -->
+
+
+### PR Checklist
+
+[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)
+
+- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
+- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
+- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
+- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
+- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
+- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
+- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
+- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
+- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
+
+### Reviewers
+
+Reviewers, please comment how you tested the PR when approving it.


### PR DESCRIPTION
### What does this PR do?
Add the new PR Template

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17486

Change-Id: I632d9498d6c13808a21478424e01ca6244018fbe
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
