### PR TITLE
Switch nightly build to GH action

### DIFF
--- a/.github/workflows/build-jobs.yml
+++ b/.github/workflows/build-jobs.yml
@@ -16,9 +16,6 @@ on:
 
 jobs:
   nightly-build-push:
-    env:
-      QUAY_ECLIPSE_CHE_USERNAME: ${{ secrets.QUAY_USERNAME }}
-      QUAY_ECLIPSE_CHE_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
     runs-on: ubuntu-latest
     steps:
       - name: Clone source code
@@ -26,5 +23,24 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Build and push image
-        run: /bin/bash cico_build_nightly.sh
+      - name: Login to quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build and push base images
+        run: /bin/bash arbitrary-users-patch/build_images.sh --push
+
+      - name: Build and push happy path image
+        run: /bin/bash arbitrary-users-patch/happy-path/build_happy_path_image.sh --push
+
+      - name: Build and push devfile image
+        run: |
+          SHORT_SHA1=$(git rev-parse --short HEAD)
+          docker build -t che-devfile-registry -f ./build/dockerfiles/Dockerfile --target registry .
+          docker tag che-devfile-registry quay.io/eclipse/che-devfile-registry:nightly
+          docker push quay.io/eclipse/che-devfile-registry:nightly
+          docker tag che-devfile-registry quay.io/eclipse/che-devfile-registry:${SHORT_SHA1}
+          docker push quay.io/eclipse/che-devfile-registry:${SHORT_SHA1}

--- a/.github/workflows/build-jobs.yml
+++ b/.github/workflows/build-jobs.yml
@@ -17,8 +17,8 @@ on:
 jobs:
   nightly-build-push:
     env:
-      QUAY_ECLIPSE_CHE_USERNAME: ${{ secrets.QUAY_DOCKER_USERNAME }}
-      QUAY_ECLIPSE_CHE_PASSWORD: ${{ secrets.QUAY_DOCKER_PASSWORD }}
+      QUAY_ECLIPSE_CHE_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_ECLIPSE_CHE_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
     runs-on: ubuntu-latest
     steps:
       - name: Clone source code

--- a/.github/workflows/build-jobs.yml
+++ b/.github/workflows/build-jobs.yml
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-name: CI Build/Push
+name: Build/Push
 
 on:
   push:

--- a/.github/workflows/build-jobs.yml
+++ b/.github/workflows/build-jobs.yml
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+name: CI Build/Push
+
+on:
+  push:
+    branches: 
+      - master
+
+jobs:
+  nightly-build-push:
+    env:
+      QUAY_ECLIPSE_CHE_USERNAME: ${{ secrets.QUAY_DOCKER_USERNAME }}
+      QUAY_ECLIPSE_CHE_PASSWORD: ${{ secrets.QUAY_DOCKER_PASSWORD }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone source code
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      - name: Build and push image
+        run: /bin/bash cico_build_nightly.sh

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-name: CI
+name: PR Checks
 
 on:
   pull_request:

--- a/.github/workflows/pr-jobs.yml
+++ b/.github/workflows/pr-jobs.yml
@@ -1,3 +1,12 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
 name: CI
 
 on:


### PR DESCRIPTION
Run a GitHub action job everytime a change is merged, instead of using centos-ci.

See eclipse/che#18072

Signed-off-by: Eric Williams <ericwill@redhat.com>
