### PR TITLE
Use java8 plugin instead of java

### DIFF
--- a/devfiles/apache-camel-springboot/devfile.yaml
+++ b/devfiles/apache-camel-springboot/devfile.yaml
@@ -19,7 +19,7 @@ components:
     memoryLimit: 260Mi
   -
     type: chePlugin
-    id: redhat/java/latest
+    id: redhat/java8/latest
     memoryLimit: 1360Mi
   -
     type: dockerimage

--- a/devfiles/java-gradle/devfile.yaml
+++ b/devfiles/java-gradle/devfile.yaml
@@ -13,6 +13,8 @@ components:
   -
     type: chePlugin
     id: redhat/java11/latest
+    preferences:
+      java.server.launchMode: Standard
   -
     type: dockerimage
     alias: gradle

--- a/devfiles/java-gradle/devfile.yaml
+++ b/devfiles/java-gradle/devfile.yaml
@@ -12,7 +12,7 @@ projects:
 components:
   -
     type: chePlugin
-    id: redhat/java11/latest
+    id: redhat/java/latest
     preferences:
       java.server.launchMode: Standard
   -

--- a/devfiles/java-maven/devfile.yaml
+++ b/devfiles/java-maven/devfile.yaml
@@ -13,6 +13,8 @@ components:
   -
     type: chePlugin
     id: redhat/java11/latest
+    preferences:
+      java.server.launchMode: Standard
   -
     type: dockerimage
     alias: maven

--- a/devfiles/java-maven/devfile.yaml
+++ b/devfiles/java-maven/devfile.yaml
@@ -12,7 +12,7 @@ projects:
 components:
   -
     type: chePlugin
-    id: redhat/java11/latest
+    id: redhat/java/latest
     preferences:
       java.server.launchMode: Standard
   -

--- a/devfiles/java-mongo/devfile.yaml
+++ b/devfiles/java-mongo/devfile.yaml
@@ -11,7 +11,7 @@ projects:
 components:
 -
   type: chePlugin
-  id: redhat/java/latest
+  id: redhat/java8/latest
   memoryLimit: 1280Mi
 -
   type: dockerimage

--- a/devfiles/java-mysql/devfile.yaml
+++ b/devfiles/java-mysql/devfile.yaml
@@ -12,7 +12,7 @@ projects:
 components:
   -
     type: chePlugin
-    id: redhat/java/latest
+    id: redhat/java8/latest
     memoryLimit: 1280Mi
   -
     type: dockerimage

--- a/devfiles/java-web-spring/devfile.yaml
+++ b/devfiles/java-web-spring/devfile.yaml
@@ -14,6 +14,8 @@ components:
     type: chePlugin
     id: redhat/java11/latest
     memoryLimit: 1512Mi
+    preferences:
+      java.server.launchMode: Standard
   -
     type: dockerimage
     alias: tools

--- a/devfiles/java-web-spring/devfile.yaml
+++ b/devfiles/java-web-spring/devfile.yaml
@@ -12,7 +12,7 @@ projects:
 components:
   -
     type: chePlugin
-    id: redhat/java11/latest
+    id: redhat/java/latest
     memoryLimit: 1512Mi
     preferences:
       java.server.launchMode: Standard

--- a/devfiles/java-web-vertx/devfile.yaml
+++ b/devfiles/java-web-vertx/devfile.yaml
@@ -11,7 +11,7 @@ projects:
 components:
   -
     type: chePlugin
-    id: redhat/java/latest
+    id: redhat/java8/latest
   -
     type: dockerimage
     alias: maven


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
This PR points some of the devfiles which uses Java 8 to use redhat/java8 plugin, since redhat/java plugin was migrated to Java 11 in https://github.com/eclipse/che-plugin-registry/pull/654 

Adds` java.server.launchMode:Standard` preference for redhat/java11 plugin to not have the vscode-java prompt

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/18170

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
To test this changes you can create a workspace on che.openshift.io by using the content of changed devfile.


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
