### PR TITLE
Make java debug port private for all Java devfiles

### DIFF
--- a/devfiles/apache-camel-springboot/devfile.yaml
+++ b/devfiles/apache-camel-springboot/devfile.yaml
@@ -47,6 +47,10 @@ components:
     endpoints:
       - name: '8080-tcp'
         port: 8080
+      - name: 'debug'
+        port: 5005
+        attributes:
+          public: 'false'
     mountSources: true
 commands:
   -

--- a/devfiles/java-gradle/devfile.yaml
+++ b/devfiles/java-gradle/devfile.yaml
@@ -37,6 +37,11 @@ components:
       - name: gradle
         containerPath: /home/gradle/.gradle
     mountSources: true
+    endpoints:
+      - name: 'debug'
+        port: 5005
+        attributes:
+          public: 'false'
 commands:
   -
     name: gradle build

--- a/devfiles/java-maven/devfile.yaml
+++ b/devfiles/java-maven/devfile.yaml
@@ -40,6 +40,11 @@ components:
     volumes:
       - name: m2
         containerPath: /home/user/.m2
+    endpoints:
+      - name: 'debug'
+        port: 5005
+        attributes:
+          public: 'false'
 commands:
   -
     name: maven build

--- a/devfiles/java-mongo/devfile.yaml
+++ b/devfiles/java-mongo/devfile.yaml
@@ -40,6 +40,10 @@ components:
       discoverable: 'true'
       public: 'true'
     port: 8443
+  - name: debug
+    attributes:
+      public: 'false'
+    port: 5005
   volumes:
   - name: m2
     containerPath: /home/user/.m2

--- a/devfiles/java-mysql/devfile.yaml
+++ b/devfiles/java-mysql/devfile.yaml
@@ -32,6 +32,10 @@ components:
     endpoints:
       - name: '8080-tcp'
         port: 8080
+      - name: 'debug'
+        port: 5005
+        attributes:
+          public: 'false'
     mountSources: true
     volumes:
       - name: m2

--- a/devfiles/java-web-spring/devfile.yaml
+++ b/devfiles/java-web-spring/devfile.yaml
@@ -34,6 +34,10 @@ components:
     endpoints:
       - name: '8080-tcp'
         port: 8080
+      - name: 'debug'
+        port: 5005
+        attributes:
+          public: 'false'
     mountSources: true
     volumes:
       - name: m2

--- a/devfiles/java-web-vertx/devfile.yaml
+++ b/devfiles/java-web-vertx/devfile.yaml
@@ -30,6 +30,10 @@ components:
     endpoints:
       - name: '8080-tcp'
         port: 8080
+      - name: 'debug'
+        port: 5005
+        attributes:
+          public: 'false'
     mountSources: true
     volumes:
       - name: m2

--- a/devfiles/quarkus-command-mode/devfile.yaml
+++ b/devfiles/quarkus-command-mode/devfile.yaml
@@ -30,8 +30,13 @@ components:
     volumes:
       - name: m2
         containerPath: /home/user/.m2
-
-  - type: dockerimage
+    endpoints:
+      - name: 'debug'
+        port: 5005
+        attributes:
+          public: 'false'
+  -
+    type: dockerimage
     alias: ubi-minimal
     image: 'registry.access.redhat.com/ubi8/ubi-minimal'
     memoryLimit: 32M

--- a/devfiles/quarkus/devfile.yaml
+++ b/devfiles/quarkus/devfile.yaml
@@ -35,8 +35,12 @@ components:
         port: 8080
         attributes:
           path: /hello/greeting/che-user
-
-  - type: dockerimage
+      - name: 'debug'
+        port: 5005
+        attributes:
+          public: 'false'
+  -
+    type: dockerimage
     alias: ubi-minimal
     image: 'registry.access.redhat.com/ubi8/ubi-minimal'
     memoryLimit: 32M

--- a/devfiles/scala-sbt/devfile.yaml
+++ b/devfiles/scala-sbt/devfile.yaml
@@ -44,6 +44,11 @@ components:
         containerPath: /home/user/.cache/metals
       - name: bloop
         containerPath: /home/user/.cache/bloop
+    endpoints:
+      - name: 'debug'
+        port: 5005
+        attributes:
+          public: 'false'
 commands:
   -
     name: sbt REPL


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
- Adds Java debug port to java container endpoints
- Marks debug port as private to prevent appearing extra notifications when running debug server


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/18138

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
To test changes your Che-Theia must have ports plugin from this PR https://github.com/eclipse/che-theia/pull/875

A devfile to test how it works with Quarkus stack
```
---
apiVersion: 1.0.0
metadata:
  generateName: quarkus-command-mode-
projects:
  -
    name: quarkus-quickstarts
    source:
      type: git
      location: "https://github.com/quarkusio/quarkus-quickstarts.git"
      sparseCheckoutDir: getting-started-command-mode
components:
  - type: cheEditor
    reference: >-
      https://gist.githubusercontent.com/vitaliy-guliy/f51fc177a6bdac3b7ba1c248b466d515/raw/f77b22e383bd9a978328e191238e7b0826340085/meta.yaml
    alias: che-theia
  -
    type: chePlugin
    id: redhat/quarkus-java11/latest
  -
    type: dockerimage
    alias: centos-quarkus-maven
    image: quay.io/eclipse/che-quarkus:nightly
    env:
      - name: JAVA_OPTS
        value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
          -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
          -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom
          -Duser.home=/home/user"
      - name: MAVEN_OPTS
        value: $(JAVA_OPTS)  
    memoryLimit: 4927M
    mountSources: true
    volumes:
      - name: m2
        containerPath: /home/user/.m2
    endpoints:
      - name: 'debug'
        port: 5005
        attributes:
          public: 'false'
  -
    type: dockerimage
    alias: ubi-minimal
    image: 'registry.access.redhat.com/ubi8/ubi-minimal'
    memoryLimit: 32M
    mountSources: true
    command: ['tail']
    args: ['-f', '/dev/null']

commands:
  -
    name: Package
    actions:
      -
        type: exec
        component: centos-quarkus-maven
        command: "mvn package"
        workdir: ${CHE_PROJECTS_ROOT}/quarkus-quickstarts/getting-started-command-mode
  -
    name: Start Development mode (Hot reload + debug)
    actions:
      -
        type: exec
        component: centos-quarkus-maven
        command: >-
          read -p 'Enter your name [Eclipse Che]: ' name;
          name=${name:-'Eclipse Che'};
          set -o xtrace;
          mvn compile quarkus:dev -Dquarkus.args="$name"
        workdir: ${CHE_PROJECTS_ROOT}/quarkus-quickstarts/getting-started-command-mode
  -
    name: Package Native
    actions:
      -
        type: exec
        component: centos-quarkus-maven
        command: "mvn package -Dnative -Dmaven.test.skip"
        workdir: ${CHE_PROJECTS_ROOT}/quarkus-quickstarts/getting-started-command-mode

  -
    name: Start Native
    actions:
      -
        type: exec
        component: ubi-minimal
        command: >-
          read -p 'Enter your name [Eclipse Che]: ' name;
          name=${name:-'Eclipse Che'};
          set -o xtrace;
          ./getting-started-command-mode-1.0-SNAPSHOT-runner $name
        workdir: ${CHE_PROJECTS_ROOT}/quarkus-quickstarts/getting-started-command-mode/target
  -
    name: Attach remote debugger
    actions:
    - type: vscode-launch
      referenceContent: |
        {
          "version": "0.2.0",
          "configurations": [
            {
              "type": "java",
              "request": "attach",
              "name": "Attach to Remote Quarkus App",
              "hostName": "localhost",
              "port": 5005
            }
          ]
        }
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
