### PR TITLE
fix(quarkus-devfiles): Limit the quarkus native compilation memory limits so it doesn't fail when it reaches the container limit

### DIFF
--- a/devfiles/quarkus-command-mode/devfile.yaml
+++ b/devfiles/quarkus-command-mode/devfile.yaml
@@ -25,7 +25,7 @@ components:
           -Duser.home=/home/user"
       - name: MAVEN_OPTS
         value: $(JAVA_OPTS)  
-    memoryLimit: 4927M
+    memoryLimit: 4G
     mountSources: true
     volumes:
       - name: m2

--- a/devfiles/quarkus-command-mode/devfile.yaml
+++ b/devfiles/quarkus-command-mode/devfile.yaml
@@ -71,7 +71,7 @@ commands:
       -
         type: exec
         component: centos-quarkus-maven
-        command: "mvn package -Dnative -Dmaven.test.skip"
+        command: "mvn package -Dnative -Dmaven.test.skip -Dquarkus.native.native-image-xmx=2G"
         workdir: ${CHE_PROJECTS_ROOT}/quarkus-quickstarts/getting-started-command-mode
 
   -

--- a/devfiles/quarkus/devfile.yaml
+++ b/devfiles/quarkus/devfile.yaml
@@ -25,7 +25,7 @@ components:
           -Duser.home=/home/user"
       - name: MAVEN_OPTS
         value: $(JAVA_OPTS)  
-    memoryLimit: 4927M
+    memoryLimit: 4G
     mountSources: true
     volumes:
       - name: m2

--- a/devfiles/quarkus/devfile.yaml
+++ b/devfiles/quarkus/devfile.yaml
@@ -76,7 +76,7 @@ commands:
       -
         type: exec
         component: centos-quarkus-maven
-        command: "./mvnw package -Dnative -Dmaven.test.skip"
+        command: "./mvnw package -Dnative -Dmaven.test.skip -Dquarkus.native.native-image-xmx=2G"
         workdir: ${CHE_PROJECTS_ROOT}/quarkus-quickstarts/getting-started
 
   -


### PR DESCRIPTION
### What does this PR do?
It avoid the compilation to fail if it is reaching the memoryLimit defined for the container.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17138


### How to test this PR?
- Command mode: https://che.openshift.io/factory?url=https://github.com/sunix/che-devfile-registry/raw/limitMemoryUsageForNativeBuild/devfiles/quarkus-command-mode/devfile.yaml
- Rest API: https://che.openshift.io/factory?url=https://github.com/sunix/che-devfile-registry/raw/limitMemoryUsageForNativeBuild/devfiles/quarkus/devfile.yaml



### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
