### PR TITLE
feat(rust-devfile): Adding the Rust plugin to the Rust stack

### DIFF
--- a/devfiles/rust/devfile.yaml
+++ b/devfiles/rust/devfile.yaml
@@ -13,6 +13,8 @@ components:
     type: dockerimage
     alias: rust
     image: quay.io/eclipse/che-rust-1.39:nightly
+  - type: chePlugin
+    id: rust-lang/rust/latest
 commands:
   - name: build
     actions:


### PR DESCRIPTION
### What does this PR do?
Adding the Rust plugin to the rust devfile

### Screenshot/screencast of this PR
Tested with
```yaml
  - type: chePlugin
    reference: 'https://gist.github.com/sunix/eb86fdf6802afbfb4de059ed19f08d37/raw/83db1b01e210c19209913fa37399846d9fd5fcbd/meta.yaml'
```
![Selection_098](https://user-images.githubusercontent.com/650571/101777478-d41b7d00-3af2-11eb-89fe-93a95a4b5508.png)


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17069

### How to test this PR?
- Create a workspace from the rust get started sample
- add the plugin above in the workspace devfile
- open main.rs, try code completion and error

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
