### PR TITLE
Multiarch build support by docker buildx

### DIFF
--- a/.github/workflows/nightly-build-publish.yml
+++ b/.github/workflows/nightly-build-publish.yml
@@ -19,9 +19,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone source code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           fetch-depth: 1
+
+      - name: Prepare
+        id: prep
+        run: |
+          SHORT_SHA1=$(git rev-parse --short HEAD)
+          echo ::set-output name=short_sha1::${SHORT_SHA1}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
 
       - name: Login to quay.io
         uses: docker/login-action@v1
@@ -37,10 +50,12 @@ jobs:
         run: /bin/bash arbitrary-users-patch/happy-path/build_happy_path_image.sh --push
 
       - name: Build and push devfile image
-        run: |
-          SHORT_SHA1=$(git rev-parse --short HEAD)
-          docker build -t che-devfile-registry -f ./build/dockerfiles/Dockerfile --target registry .
-          docker tag che-devfile-registry quay.io/eclipse/che-devfile-registry:nightly
-          docker push quay.io/eclipse/che-devfile-registry:nightly
-          docker tag che-devfile-registry quay.io/eclipse/che-devfile-registry:${SHORT_SHA1}
-          docker push quay.io/eclipse/che-devfile-registry:${SHORT_SHA1}
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/dockerfiles/Dockerfile
+          target: registry
+          platforms: linux/amd64,linux/s390x
+          tags: quay.io/eclipse/che-devfile-registry:nightly,quay.io/eclipse/che-devfile-registry:${{ steps.prep.outputs.short_sha1 }}
+          push: true

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -18,7 +18,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Shellcheck
         run: |
@@ -28,7 +28,9 @@ jobs:
   digest-validation:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+      with:
+          fetch-depth: 0
     - name: Run script which checks container image digest
       run: |
         sudo pip install yq
@@ -39,38 +41,45 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - name: 'Checkout Source Code'
+      uses: actions/checkout@v2
 
-    - name: Cache docker layers
-      uses: actions/cache@v1
-      with:
-        path: ./caches
-        key: v1-${{ github.head_ref }}
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
         
-    - name: Load docker layer cache
-      run: |
-        set +o pipefail
-        docker load -i ./caches/app.tar | true
-    
-    - name: Build devfile registry
-      run: |
-        docker build \
-          --cache-from=app \
-          -t app \
-          -f ./build/dockerfiles/Dockerfile \
-          --target registry .
-           
     - name: Cache docker layers
-      run: |
-        mkdir -p ./caches
-        docker save -o ./caches/app.tar app
+      uses: actions/cache@v2
+      id: cache
+      with:
+        path: /tmp/.buildx-cache
+        key: v2-${{ github.head_ref }}
+    
+    - name: 'Docker Prepare'
+      run: docker image prune -a -f
+
+    - name: Build devfile registry
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./build/dockerfiles/Dockerfile
+        target: registry
+        platforms: linux/amd64,linux/s390x
+        tags: app
+        cache-from: "type=local,src=/tmp/.buildx-cache"
+        cache-to: "type=local,dest=/tmp/.buildx-cache"
+        push: false
     
     - name: Build offline devfile registry
-      run: |
-        docker build \
-          --cache-from=app \
-          -t app \
-          -f ./build/dockerfiles/Dockerfile \
-          --target offline-registry .
-   
-
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./build/dockerfiles/Dockerfile
+        target: offline-registry
+        platforms: linux/amd64,linux/s390x
+        tags: app
+        cache-from: "type=local,src=/tmp/.buildx-cache"
+        push: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone source code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           fetch-depth: 1
           ref: release
+
+      - name: Prepare
+        id: prep
+        run: |
+          SHORT_SHA1=$(git rev-parse --short HEAD)
+          echo ::set-output name=short_sha1::${SHORT_SHA1}
+          VERSION=$(head -n 1 VERSION)
+          echo ::set-output name=version::${VERSION}
+          IMAGE=che-devfile-registry
+          echo ::set-output name=image::${IMAGE}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
 
       - name: Login to Quay.io
         uses: azure/docker-login@v1
@@ -46,13 +63,15 @@ jobs:
           /bin/bash arbitrary-users-patch/build_images.sh --push
 
       - name: Build and push images
-        run: |
-          SHORT_SHA1=$(git rev-parse --short HEAD)
-          VERSION=$(head -n 1 VERSION)
-          IMAGE=che-devfile-registry
-          DOCKERFILE_PATH=./build/dockerfiles/Dockerfile
-          docker build -t ${IMAGE} -f ${DOCKERFILE_PATH} --build-arg PATCHED_IMAGES_TAG=${VERSION} --target registry .
-          docker tag ${IMAGE} quay.io/eclipse/${IMAGE}:${SHORT_SHA1}
-          docker push quay.io/eclipse/${IMAGE}:${SHORT_SHA1}
-          docker tag ${IMAGE} quay.io/eclipse/${IMAGE}:${VERSION}
-          docker push quay.io/eclipse/${IMAGE}:${VERSION}
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/dockerfiles/Dockerfile
+          target: registry
+          build-args: |
+            PATCHED_IMAGES_TAG=${{ steps.prep.outputs.version }}
+          platforms: linux/amd64,linux/s390x
+          tags: quay.io/eclipse/${{ steps.prep.outputs.image }}:${{ steps.prep.outputs.version }},quay.io/eclipse/${{ steps.prep.outputs.image }}:${{ steps.prep.outputs.short_sha1 }}
+          push: true
+


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Enables docker buildx support in GitHub Actions job to build and publish multiarch docker images. All the workflows (nightly build, PR check, and release) are updated to have multiarch support. 

### What issues does this PR fix or reference?
This refers to [#17124](https://github.com/eclipse/che/issues/17124). As per @nickboldt's [comment](https://github.com/eclipse/che-devfile-registry/pull/250#issuecomment-740180491) on #250, raised this PR to add multiarch support.




