### PR TITLE
Add support for building with buildah

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ Options:
 ```
 By default, the built registry will be tagged `quay.io/eclipse/che-devfile-registry:nightly`, and will be built with offline mode disabled.
 
+This script listens to the `BUILDER` variable, and will use the tool specified there to build the image. For example:
+```sh
+BUILDER=buildah ./build.sh
+```
+
+will force the build to use `buildah`. If `BUILDER` is not specified, the script will try to use `podman` by default. If `podman` is not installed, then `buildah` will be chosen. If neither `podman` nor `buildah` are installed, the script will finally try to build with `docker`.
+
 Note that the Dockerfiles in this repository utilize multi-stage builds, so Docker version 17.05 or higher is required.
 
 ### Offline and airgapped registry images

--- a/build.sh
+++ b/build.sh
@@ -78,12 +78,43 @@ function parse_arguments() {
 
 parse_arguments "$@"
 
+BUILD_COMMAND="build"
+if [[ -z $BUILDER ]]; then
+    echo "BUILDER not specified, trying with podman"
+    BUILDER=$(command -v podman || true)
+    if [[ ! -x $BUILDER ]]; then
+        echo "[WARNING] podman is not installed, trying with buildah"
+        BUILDER=$(command -v buildah || true)
+        if [[ ! -x $BUILDER ]]; then
+            echo "[WARNING] buildah is not installed, trying with docker"
+            BUILDER=$(command -v docker || true)
+            if [[ ! -x $BUILDER ]]; then
+                echo "[ERROR] neither docker, buildah, nor podman are installed. Aborting"; exit 1
+            fi
+        else
+            BUILD_COMMAND="bud"
+        fi
+    fi
+else
+    if [[ ! -x $(command -v "$BUILDER" || true) ]]; then
+        echo "Builder $BUILDER is missing. Aborting."; exit 1
+    fi
+    if [[ $BUILDER =~ "docker" || $BUILDER =~ "podman" ]]; then
+        if [[ ! $($BUILDER ps) ]]; then
+            echo "Builder $BUILDER is not functioning. Aborting."; exit 1
+        fi
+    fi
+    if [[ $BUILDER =~ "buildah" ]]; then
+        BUILD_COMMAND="bud"
+    fi
+fi
+
 IMAGE="${REGISTRY}/${ORGANIZATION}/che-devfile-registry:${TAG}"
 VERSION=$(head -n 1 VERSION)
 case $VERSION in
   *SNAPSHOT)
     echo "Snapshot version (${VERSION}) specified in $(find . -name VERSION): building nightly plugin registry."
-    docker build \
+    ${BUILDER} ${BUILD_COMMAND} \
         -t "${IMAGE}" \
         -f ${DOCKERFILE} \
         --build-arg "USE_DIGESTS=${USE_DIGESTS}" \
@@ -91,7 +122,7 @@ case $VERSION in
     ;;
   *)
     echo "Release version specified in $(find . -name VERSION): Building plugin registry for release ${VERSION}."
-    docker build \
+    ${BUILDER} ${BUILD_COMMAND} \
         -t "${IMAGE}" \
         -f "${DOCKERFILE}" \
         --build-arg "PATCHED_IMAGES_TAG=${VERSION}" \


### PR DESCRIPTION
Signed-off-by: Eric Williams <ericwill@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Not all users have access to docker, so use podman/buildah by default and use docker as a last resort.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->

Fixes of eclipse/che#18798

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
Run the build script with `BUILDER=buildah ./build.sh`, or try running just `build.sh` and observe that a tool will be auto-detected based on what's installed on your machine.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
