### PR TITLE
Use generateName for bash devfile to match others

### DIFF
--- a/devfiles/bash/devfile.yaml
+++ b/devfiles/bash/devfile.yaml
@@ -1,6 +1,6 @@
 apiVersion: 1.0.0
 metadata:
-  name: bash
+  generateName: bash-
 projects:
   - name: bash
     source:


### PR DESCRIPTION
### What does this PR do?
Change the bash sample to use `generateName`, matching other sample devfiles in this repo.
