### PR TITLE
Added multiarch support by docker buildx

### DIFF
--- a/.github/workflows/nightly-build-publish.yml
+++ b/.github/workflows/nightly-build-publish.yml
@@ -18,29 +18,55 @@ jobs:
   nightly-build-publish:
     runs-on: ubuntu-latest
     steps:
-      - name: Clone source code
+      - 
+        name: Clone source code
         uses: actions/checkout@v1
         with:
           fetch-depth: 1
-
-      - name: Login to quay.io
+      - 
+        name: Prepare
+        id: prep
+        run: |
+          SHORT_SHA1=$(git rev-parse --short HEAD)
+          echo ::set-output name=short_sha1::${SHORT_SHA1}
+          VERSION=$(head -n 1 VERSION)
+          echo ::set-output name=version::${VERSION}
+          IMAGE=che-devfile-registry
+          echo ::set-output name=image::${IMAGE}
+          PLATFORMS=$(cat PLATFORMS)
+          echo ::set-output name=platforms::${PLATFORMS}
+      -
+        name: "Set up QEMU"
+        uses: docker/setup-qemu-action@v1
+      -
+        name: "Set up Docker Buildx"
+        uses: docker/setup-buildx-action@v1
+      -
+        name: "Docker quay.io Login"
         uses: docker/login-action@v1
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
+      - 
+        name: Login to docker.io
+        uses: docker/login-action@v1
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build and push base images
         run: /bin/bash arbitrary-users-patch/build_images.sh --push
 
       - name: Build and push happy path image
         run: /bin/bash arbitrary-users-patch/happy-path/build_happy_path_image.sh --push
-
-      - name: Build and push devfile image
-        run: |
-          SHORT_SHA1=$(git rev-parse --short HEAD)
-          docker build -t che-devfile-registry -f ./build/dockerfiles/Dockerfile --target registry .
-          docker tag che-devfile-registry quay.io/eclipse/che-devfile-registry:nightly
-          docker push quay.io/eclipse/che-devfile-registry:nightly
-          docker tag che-devfile-registry quay.io/eclipse/che-devfile-registry:${SHORT_SHA1}
-          docker push quay.io/eclipse/che-devfile-registry:${SHORT_SHA1}
+      -
+        name: "Build and push"
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/dockerfiles/Dockerfile
+          platforms: ${{ steps.package.outputs.content }}
+          tags:  quay.io/eclipse/${{ steps.prep.outputs.image }}:${{ steps.prep.outputs.version }},quay.io/eclipse/${{ steps.prep.outputs.image }}:${{ steps.prep.outputs.short_sha1 }}
+          push: true 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -41,6 +41,20 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
+    - 
+      name: Prepare
+      id: prep
+      run: |
+        PLATFORMS=$(cat PLATFORMS)
+        echo ::set-output name=platforms::${PLATFORMS}
+        
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+      
     - name: Cache docker layers
       uses: actions/cache@v1
       with:
@@ -53,23 +67,24 @@ jobs:
         docker load -i ./caches/app.tar | true
     
     - name: Build devfile registry
-      run: |
-        docker build \
-          --cache-from=app \
-          -t app \
-          -f ./build/dockerfiles/Dockerfile \
-          --target registry .
-           
-    - name: Cache docker layers
-      run: |
-        mkdir -p ./caches
-        docker save -o ./caches/app.tar app
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./build/dockerfiles/Dockerfile
+        target: registry
+        platforms: ${{ steps.prep.outputs.platforms }}
+        tags: app
+        cache-from: "type=local,src=/tmp/.buildx-cache"
+        cache-to: "type=local,dest=/tmp/.buildx-cache"
+        push: false
     
     - name: Build offline devfile registry
-      run: |
-        docker build \
-          --cache-from=app \
-          -t app \
-          -f ./build/dockerfiles/Dockerfile \
-          --target offline-registry .
-   
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./build/dockerfiles/Dockerfile
+        target: offline-registry
+        platforms: ${{ steps.prep.outputs.platforms }}
+        tags: app
+        cache-from: "type=local,src=/tmp/.buildx-cache"
+        push: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,29 +17,51 @@ on:
         required: true
 
 jobs:
-  release-build-publish:
+  build:
+    name: Create Che Devfile Registry Release
     runs-on: ubuntu-latest
     steps:
-      - name: Clone source code
+      -
+        name: "Checkout  source code"
         uses: actions/checkout@v1
         with:
           fetch-depth: 1
           ref: release
-
-      - name: Login to Quay.io
-        uses: azure/docker-login@v1
+      - 
+        name: Prepare
+        id: prep
+        run: |
+          SHORT_SHA1=$(git rev-parse --short HEAD)
+          echo ::set-output name=short_sha1::${SHORT_SHA1}
+          VERSION=$(head -n 1 VERSION)
+          echo ::set-output name=version::${VERSION}
+          IMAGE=che-devfile-registry
+          echo ::set-output name=image::${IMAGE}
+          PLATFORMS=$(cat PLATFORMS)
+          echo ::set-output name=platforms::${PLATFORMS}
+      -
+        name: "Set up QEMU"
+        uses: docker/setup-qemu-action@v1
+      -
+        name: "Set up Docker Buildx"
+        uses: docker/setup-buildx-action@v1
+      -
+        name: "Docker quay.io Login"
+        uses: docker/login-action@v1
         with:
-          login-server: quay.io
+          registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
-
-      - name: Login to Docker Hub
-        uses: azure/docker-login@v1
+      - 
+        name: Login to docker.io
+        uses: docker/login-action@v1
         with:
+          registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-      - name: Build and push patched base images and happy path image
+          
+      - 
+        name: Build and push patched base images and happy path image
         run: |
           export GITHUB_TOKEN=${{ secrets.CHE_BOT_GITHUB_TOKEN }}
           ./make-release.sh --version ${{ github.event.inputs.version}} --trigger-release

--- a/PLATFORMS
+++ b/PLATFORMS
@@ -1,0 +1,1 @@
+linux/amd64,linux/ppc64le,linux/arm64

--- a/arbitrary-users-patch/PLATFORMS
+++ b/arbitrary-users-patch/PLATFORMS
@@ -1,0 +1,1 @@
+linux/amd64,linux/ppc64le,linux/arm64

--- a/arbitrary-users-patch/build_images.sh
+++ b/arbitrary-users-patch/build_images.sh
@@ -20,6 +20,8 @@ REGISTRY=${REGISTRY:-${DEFAULT_REGISTRY}}
 ORGANIZATION=${ORGANIZATION:-${DEFAULT_ORGANIZATION}}
 TAG=${TAG:-${DEFAULT_TAG}}
 
+PLATFORMS=$(cat arbitrary-users-patch/PLATFORMS)
+
 NAME_FORMAT="${REGISTRY}/${ORGANIZATION}"
 
 PUSH_IMAGES=false
@@ -32,7 +34,7 @@ while read -r line; do
   base_image_name=$(echo "$line" | tr -s ' ' | cut -f 1 -d ' ')
   base_image=$(echo "$line" | tr -s ' ' | cut -f 2 -d ' ')
   echo "Building ${NAME_FORMAT}/${base_image_name}:${TAG} based on $base_image ..."
-  docker build -t "${NAME_FORMAT}/${base_image_name}:${TAG}" --no-cache --build-arg FROM_IMAGE="$base_image" "${SCRIPT_DIR}"/ | cat
+  docker buildx build --platform "$PLATFORMS" -t "${NAME_FORMAT}/${base_image_name}:${TAG}" --no-cache --build-arg FROM_IMAGE="$base_image" "${SCRIPT_DIR}"/ | cat
   if ${PUSH_IMAGES}; then
     echo "Pushing ${NAME_FORMAT}/${base_image_name}:${TAG}" to remote registry
     docker push "${NAME_FORMAT}/${base_image_name}:${TAG}" | cat

--- a/arbitrary-users-patch/happy-path/PLATFORMS
+++ b/arbitrary-users-patch/happy-path/PLATFORMS
@@ -1,0 +1,1 @@
+linux/amd64,linux/ppc64le,linux/arm64

--- a/arbitrary-users-patch/happy-path/build_happy_path_image.sh
+++ b/arbitrary-users-patch/happy-path/build_happy_path_image.sh
@@ -20,6 +20,8 @@ REGISTRY=${REGISTRY:-${DEFAULT_REGISTRY}}
 ORGANIZATION=${ORGANIZATION:-${DEFAULT_ORGANIZATION}}
 TAG=${TAG:-${DEFAULT_TAG}}
 
+PLATFORMS=$(cat arbitrary-users-patch/happy-path/PLATFORMS)
+
 NAME_FORMAT="${REGISTRY}/${ORGANIZATION}"
 
 PUSH_IMAGES=false
@@ -28,7 +30,7 @@ if [ "$1" == "--push" ]; then
 fi
 
 # Build image for happy-path tests with precashed mvn dependencies
-docker build -t "${NAME_FORMAT}/happy-path:${TAG}" --no-cache --build-arg TAG="${TAG}" "${SCRIPT_DIR}"/  | cat
+docker buildx build --platform "$PLATFORMS" -t "${NAME_FORMAT}/happy-path:${TAG}" --no-cache --build-arg TAG="${TAG}" "${SCRIPT_DIR}"/  | cat
 if ${PUSH_IMAGES}; then
     echo "Pushing ${NAME_FORMAT}/happy-path:${TAG}" to remote registry
     docker push "${NAME_FORMAT}/happy-path:${TAG}" | cat

--- a/make-release.sh
+++ b/make-release.sh
@@ -38,7 +38,7 @@ performRelease()
   VERSION=$(head -n 1 VERSION)
   IMAGE=che-devfile-registry
   DOCKERFILE_PATH=./build/dockerfiles/Dockerfile
-  docker build -t ${IMAGE} -f ${DOCKERFILE_PATH} --build-arg PATCHED_IMAGES_TAG="${VERSION}" --target registry .
+  docker buildx build --platform "$PLATFORMS" -t ${IMAGE} -f ${DOCKERFILE_PATH} --build-arg PATCHED_IMAGES_TAG="${VERSION}" --target registry .
   docker tag ${IMAGE} "quay.io/eclipse/${IMAGE}:${SHORT_SHA1}"
   docker push "quay.io/eclipse/${IMAGE}:${SHORT_SHA1}"
   docker tag ${IMAGE} "quay.io/eclipse/${IMAGE}:${VERSION}"


### PR DESCRIPTION
Signed-off-by: Bivas Das <bivasda1@in.ibm.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Enables docker buildx support in GitHub Actions job to build and publish multiarch docker images. All the workflows (nightly build, PR check, and release) are updated to have multiarch support.

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
This refers to https://github.com/eclipse/che-devfile-registry/pull/321

### Reviewers
@ericwill Could you please review this PR
