### PR TITLE
Removing the CHE_DEVFILE_REGISTRY_URL from the plugin reference

### DIFF
--- a/devfiles/quarkus/devfile.yaml
+++ b/devfiles/quarkus/devfile.yaml
@@ -57,7 +57,7 @@ components:
 
   - id: redhat/vscode-didact/latest
     preferences:
-      didact.defaultUrl: "{{ DEVFILE_REGISTRY_URL }}/devfiles/quarkus/didact.md"
+      didact.defaultUrl: "https://che-devfile-registry.prod-preview.openshift.io/devfiles/quarkus/didact.md"
       che.welcome.enable: false
       didact.openDefaultTutorialAtStartup: true
     type: chePlugin


### PR DESCRIPTION
Currently `CHE_DEVFILE_REGISTRY_URL` reference is failing on production. 
workaround since we do not plan to update devfile registry on stg and production anymore