### PR TITLE
fix(quarkus-devfile): clone with sparseCheckoutDir not working after repository default branch change to main

### DIFF
--- a/devfiles/quarkus-command-mode/devfile.yaml
+++ b/devfiles/quarkus-command-mode/devfile.yaml
@@ -9,6 +9,7 @@ projects:
       type: git
       location: "https://github.com/quarkusio/quarkus-quickstarts.git"
       sparseCheckoutDir: getting-started-command-mode
+      branch: main
 components:
   -
     type: chePlugin

--- a/devfiles/quarkus/devfile.yaml
+++ b/devfiles/quarkus/devfile.yaml
@@ -9,6 +9,7 @@ projects:
       type: git
       location: "https://github.com/quarkusio/quarkus-quickstarts.git"
       sparseCheckoutDir: getting-started
+      branch: main
 components:
   -
     type: chePlugin


### PR DESCRIPTION
### What does this PR do?
Quarkus quickstart repos has its default branch renamed from `master` to `main`. It looks like it is an issue with sparseCheckoutDir. This is a quick-fix.

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
quick-fix for https://github.com/eclipse/che/issues/19346

### How to test this PR?
Set your default devfile registry to https://sunix-che-devfile-registry-fix-quarkus-wuh9w.surge.sh, for instance:

```
kubectl edit CheCluster/eclipse-che -n eclipse-che
```
and use these values:
```
    devfileRegistryUrl: https://sunix-che-devfile-registry-fix-quarkus-wuh9w.surge.sh
    externalDevfileRegistry: true
```

Wait for che-server to be redeployed and verify that the Create a custom workspace from `Quarkus Rest API` template. Verify that `branch: main` is set. Start the workspace, verify that the project is cloned.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
