### PR TITLE
Cache images in browser cache with etags

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -5,7 +5,7 @@ DirectoryIndex README.md
 AddType image/svg+xml svg svgz
 AddEncoding gzip svgz
 
-<FilesMatch "\.(json|yaml|svg|png)$">
+<FilesMatch "\.(json|yaml)$">
 
   <IfModule mod_expires.c>
     ExpiresActive Off
@@ -20,5 +20,12 @@ AddEncoding gzip svgz
     Header set Pragma "no-cache"
     Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
     Header set Expires "Mon, 10 Apr 1972 00:00:00 GMT"
+  </IfModule>
+</FilesMatch>
+
+<FilesMatch "\.(svg|png)$">
+  <IfModule mod_headers.c>
+    Header unset Last-Modified
+    FileETag MTime Size
   </IfModule>
 </FilesMatch>


### PR DESCRIPTION
### What does this PR do?
This PR makes browser cache devfile images with ETags.

I tested it and image is reloaded after change.
The time benefit is not much, but it presents.
![Screenshot_20210322_102043](https://user-images.githubusercontent.com/5887312/111960397-5e16b100-8af8-11eb-91cb-b7df4878fa12.png)


### What are alternatives?
Better alternative could be if we hard cache images for some period like 1 week, and make browser reload updated resources by renaming images files to contains their hashes.
But it requires more changes on devfile registry.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16296
